### PR TITLE
WIP: sketch of externalized hsmd

### DIFF
--- a/bitcoin/tx.c
+++ b/bitcoin/tx.c
@@ -398,6 +398,7 @@ struct bitcoin_tx *bitcoin_tx(const tal_t *ctx,
 	tx->input_amounts = tal_arrz(tx, struct amount_sat*, input_count);
 	tx->wtx->locktime = 0;
 	tx->wtx->version = 2;
+    tx->output_witscripts = tal_arrz(tx, struct witscript*, output_count);
 	tx->chainparams = chainparams;
 	return tx;
 }

--- a/bitcoin/tx.h
+++ b/bitcoin/tx.h
@@ -12,6 +12,10 @@
 
 #define BITCOIN_TX_DEFAULT_SEQUENCE 0xFFFFFFFF
 
+struct witscript {
+    u8 *ptr;
+};
+
 struct bitcoin_txid {
 	struct sha256_double shad;
 };
@@ -23,6 +27,9 @@ struct bitcoin_tx {
 	 * unknown) */
 	struct amount_sat **input_amounts;
 	struct wally_tx *wtx;
+
+	/* Need the output wscripts in the HSM to validate transaction */
+	struct witscript **output_witscripts;
 
 	/* Keep a reference to the ruleset we have to abide by */
 	const struct chainparams *chainparams;

--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -991,9 +991,13 @@ static secp256k1_ecdsa_signature *calc_commitsigs(const tal_t *ctx,
 			  &wscripts, peer->channel, &peer->remote_per_commit,
 			  commit_index, REMOTE);
 
-	msg = towire_hsm_sign_remote_commitment_tx(NULL, txs[0],
-						   &peer->channel->funding_pubkey[REMOTE],
-						   *txs[0]->input_amounts[0]);
+	msg = towire_hsm_sign_remote_commitment_tx(
+		NULL, txs[0],
+		&peer->channel->funding_pubkey[REMOTE],
+		*txs[0]->input_amounts[0],
+		(const struct witscript **) txs[0]->output_witscripts,
+		&peer->remote_per_commit,
+		peer->channel->option_static_remotekey);
 
 	msg = hsm_req(tmpctx, take(msg));
 	if (!fromwire_hsm_sign_tx_reply(msg, commit_sig))

--- a/channeld/commit_tx.c
+++ b/channeld/commit_tx.c
@@ -36,7 +36,8 @@ size_t commit_tx_num_untrimmed(const struct htlc **htlcs,
 
 static void add_offered_htlc_out(struct bitcoin_tx *tx, size_t n,
 				 const struct htlc *htlc,
-				 const struct keyset *keyset)
+				 const struct keyset *keyset,
+				 struct witscript * o_wscript)
 {
 	struct ripemd160 ripemd;
 	u8 *wscript, *p2wsh;
@@ -49,12 +50,15 @@ static void add_offered_htlc_out(struct bitcoin_tx *tx, size_t n,
 	SUPERVERBOSE("# HTLC %" PRIu64 " offered %s wscript %s\n", htlc->id,
 		     type_to_string(tmpctx, struct amount_sat, &amount),
 		     tal_hex(wscript, wscript));
+	o_wscript->ptr = tal_dup_arr(o_wscript, u8,
+				     wscript, tal_count(wscript), 0);
 	tal_free(wscript);
 }
 
 static void add_received_htlc_out(struct bitcoin_tx *tx, size_t n,
 				  const struct htlc *htlc,
-				  const struct keyset *keyset)
+				  const struct keyset *keyset,
+				  struct witscript * o_wscript)
 {
 	struct ripemd160 ripemd;
 	u8 *wscript, *p2wsh;
@@ -72,6 +76,8 @@ static void add_received_htlc_out(struct bitcoin_tx *tx, size_t n,
 		     type_to_string(tmpctx, struct amount_sat,
 				    &amount),
 		     tal_hex(wscript, wscript));
+	o_wscript->ptr = tal_dup_arr(o_wscript, u8,
+				     wscript, tal_count(wscript), 0);
 	tal_free(wscript);
 }
 
@@ -170,7 +176,10 @@ struct bitcoin_tx *commit_tx(const tal_t *ctx,
 			continue;
 		if (trim(htlcs[i], feerate_per_kw, dust_limit, side))
 			continue;
-		add_offered_htlc_out(tx, n, htlcs[i], keyset);
+		tx->output_witscripts[n] =
+			tal(tx->output_witscripts, struct witscript);
+		add_offered_htlc_out(tx, n, htlcs[i], keyset,
+				     tx->output_witscripts[n]);
 		(*htlcmap)[n] = htlcs[i];
 		cltvs[n] = abs_locktime_to_blocks(&htlcs[i]->expiry);
 		n++;
@@ -186,7 +195,10 @@ struct bitcoin_tx *commit_tx(const tal_t *ctx,
 			continue;
 		if (trim(htlcs[i], feerate_per_kw, dust_limit, side))
 			continue;
-		add_received_htlc_out(tx, n, htlcs[i], keyset);
+		tx->output_witscripts[n] =
+			tal(tx->output_witscripts, struct witscript);
+		add_received_htlc_out(tx, n, htlcs[i], keyset,
+				      tx->output_witscripts[n]);
 		(*htlcmap)[n] = htlcs[i];
 		cltvs[n] = abs_locktime_to_blocks(&htlcs[i]->expiry);
 		n++;
@@ -210,6 +222,11 @@ struct bitcoin_tx *commit_tx(const tal_t *ctx,
 		SUPERVERBOSE("# to-local amount %s wscript %s\n",
 			     type_to_string(tmpctx, struct amount_sat, &amount),
 			     tal_hex(tmpctx, wscript));
+		tx->output_witscripts[n] =
+			tal(tx->output_witscripts, struct witscript);
+		tx->output_witscripts[n]->ptr =
+			tal_dup_arr(tx->output_witscripts[n], u8,
+						wscript, tal_count(wscript), 0);
 		n++;
 	}
 
@@ -253,6 +270,7 @@ struct bitcoin_tx *commit_tx(const tal_t *ctx,
 
 	assert(n <= tx->wtx->outputs_allocation_len);
 	tal_resize(htlcmap, n);
+	tal_resize(&(tx->output_witscripts), n);
 
 	/* BOLT #3:
 	 *

--- a/common/initial_commit_tx.c
+++ b/common/initial_commit_tx.c
@@ -176,6 +176,11 @@ struct bitcoin_tx *initial_commit_tx(const tal_t *ctx,
 		int pos = bitcoin_tx_add_output(
 		    tx, scriptpubkey_p2wsh(tx, wscript), amount);
 		assert(pos == n);
+		tx->output_witscripts[n] =
+			tal(tx->output_witscripts, struct witscript);
+		tx->output_witscripts[n]->ptr =
+			tal_dup_arr(tx->output_witscripts[n], u8,
+						wscript, tal_count(wscript), 0);
 		n++;
 	}
 
@@ -203,6 +208,8 @@ struct bitcoin_tx *initial_commit_tx(const tal_t *ctx,
 
 	assert(n <= tx->wtx->num_outputs);
 
+	tal_resize(&(tx->output_witscripts), n);
+	
 	/* BOLT #3:
 	 *
 	 * 7. Sort the outputs into [BIP 69+CLTV

--- a/common/permute_tx.c
+++ b/common/permute_tx.c
@@ -174,5 +174,12 @@ void permute_outputs(struct bitcoin_tx *tx, u32 *cltvs, const void **map)
 
 		/* Swap best into first place. */
 		swap_wally_outputs(tx->wtx->outputs, map, cltvs, i, best_pos);
+
+		/* If output_witscripts are present, swap them to match. */
+		if (tx->output_witscripts) {
+			struct witscript *tmp = tx->output_witscripts[i];
+			tx->output_witscripts[i] = tx->output_witscripts[best_pos];
+			tx->output_witscripts[best_pos] = tmp;
+		}
 	}
 }

--- a/hsmd/.gitignore
+++ b/hsmd/.gitignore
@@ -1,0 +1,3 @@
+/api.proto
+/api_pb2.py
+/api_pb2_grpc.py

--- a/hsmd/Makefile
+++ b/hsmd/Makefile
@@ -6,7 +6,12 @@ hsmd-wrongdir:
 
 default: hsmd-all
 
+CFLAGS += -I/usr/include/python3.7m
+LDLIBS += -lpython3.7m
+
 LIGHTNINGD_HSM_SRC := hsmd/hsmd.c	\
+	hsmd/py_types.c					\
+	hsmd/py_hsmd.c					\
 	hsmd/gen_hsm_wire.c
 LIGHTNINGD_HSM_HEADERS := hsmd/gen_hsm_wire.h
 LIGHTNINGD_HSM_OBJS := $(LIGHTNINGD_HSM_SRC:.c=.o)
@@ -47,7 +52,9 @@ ALL_OBJS += $(LIGHTNINGD_HSM_OBJS)
 ALL_PROGRAMS += lightningd/lightning_hsmd
 ALL_GEN_HEADERS += hsmd/gen_hsm_wire.h
 
-hsmd-all: lightningd/lightning_hsmd
+GEN_HSMD_PY = hsmd/api_pb2.py hsmd/api_pb2_grpc.py
+
+hsmd-all: lightningd/lightning_hsmd $(GEN_HSMD_PY)
 
 lightningd/lightning_hsmd: $(LIGHTNINGD_HSM_OBJS) $(LIGHTNINGD_LIB_OBJS) $(HSMD_COMMON_OBJS) $(BITCOIN_OBJS) $(WIRE_OBJS)
 
@@ -56,6 +63,9 @@ hsmd/gen_hsm_wire.h: $(WIRE_GEN) hsmd/hsm_wire.csv
 
 hsmd/gen_hsm_wire.c: $(WIRE_GEN) hsmd/hsm_wire.csv
 	$(WIRE_GEN) --page impl ${@:.c=.h} hsm_wire_type < hsmd/hsm_wire.csv > $@
+
+$(GEN_HSMD_PY): hsmd/api.proto
+	cd hsmd; ./regen.sh
 
 check-source: $(LIGHTNINGD_HSM_ALLSRC_NOGEN:%=check-src-include-order/%) $(LIGHTNINGD_HSM_ALLHEADERS_NOGEN:%=check-hdr-include-order/%)
 check-source-bolt: $(LIGHTNINGD_HSM_SRC:%=bolt-check/%)
@@ -66,5 +76,6 @@ clean: lightningd/hsm-clean
 
 lightningd/hsm-clean:
 	$(RM) $(LIGHTNINGD_HSM_OBJS) hsmd/gen_*
+	$(RM) hsmd/api_pb2.py hsmd/api_pb2_grpc.py
 
 -include hsmd/test/Makefile

--- a/hsmd/hsm_wire.csv
+++ b/hsmd/hsm_wire.csv
@@ -158,6 +158,10 @@ msgtype,hsm_sign_remote_commitment_tx,19
 msgdata,hsm_sign_remote_commitment_tx,tx,bitcoin_tx,
 msgdata,hsm_sign_remote_commitment_tx,remote_funding_key,pubkey,
 msgdata,hsm_sign_remote_commitment_tx,funding_amount,amount_sat,
+msgdata,hsm_sign_remote_commitment_tx,num_witscripts,u16,
+msgdata,hsm_sign_remote_commitment_tx,output_witscripts,witscript,num_witscripts
+msgdata,hsm_sign_remote_commitment_tx,remote_per_commit,pubkey,
+msgdata,hsm_sign_remote_commitment_tx,option_static_remotekey,bool,
 
 # channeld asks HSM to sign remote HTLC tx.
 msgtype,hsm_sign_remote_htlc_tx,20

--- a/hsmd/hsmd.py
+++ b/hsmd/hsmd.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+
+import api_pb2_grpc
+import coincurve
+import grpc
+import pycoin
+import struct
+import sys
+
+# Needed because pytest loses stderr from the hsmd process.
+import functools
+import traceback
+
+from api_pb2 import (
+    BIP32KeyVersion, ChainParams, SignDescriptor, KeyLocator, TxOut,
+    InitHSMReq,
+    ECDHReq,
+    PassClientHSMFdReq,
+    GetPerCommitmentPointReq,
+    SignWithdrawalTxReq, 
+    SignRemoteCommitmentTxReq,
+    SignRemoteHTLCTxReq,
+    SignMutualCloseTxReq,
+)
+
+from pycoin.symbols.btc import network
+
+Tx = network.tx
+
+def debug(*objs):
+    ff = sys.stdout
+    print(*objs, file=ff)
+    ff.flush()
+
+# Needed because pytest loses stderr from the hsmd process.
+def stdout_exceptions(function):
+    """
+    A decorator that wraps the passed in function and logs
+    exceptions to the debug stream.
+    """
+    @functools.wraps(function)
+    def wrapper(*args, **kwargs):
+        try:
+            return function(*args, **kwargs)
+        except:
+            traceback.print_exc(file=sys.stdout)
+            sys.stdout.flush()
+            raise
+    return wrapper
+
+stub = None
+def setup():
+    global stub
+    channel = grpc.insecure_channel('localhost:50051')
+    stub = api_pb2_grpc.SignerStub(channel)
+
+# message 11
+@stdout_exceptions
+def init_hsm(bip32_key_version,
+             chainparams,
+             hsm_encryption_key,
+             privkey,
+             seed,
+             secrets,
+             shaseed,
+             hsm_secret):
+    global stub
+    debug("PYHSMD init_hsm", locals())
+
+    req = InitHSMReq()
+    req.key_version.pubkey_version = bip32_key_version['bip32_pubkey_version']
+    req.key_version.privkey_version = bip32_key_version['bip32_privkey_version']
+    req.chainparams.network_name = chainparams['network_name']
+    req.chainparams.bip173_name = chainparams['bip173_name']
+    req.chainparams.bip70_name = chainparams['bip70_name']
+    req.chainparams.genesis_blockhash = \
+        chainparams['genesis_blockhash']['shad']['sha']
+    req.chainparams.rpc_port = chainparams['rpc_port']
+    req.chainparams.cli = chainparams['cli']
+    req.chainparams.cli_args = chainparams['cli_args']
+    req.chainparams.cli_min_supported_version = \
+        chainparams['cli_min_supported_version']
+    req.chainparams.dust_limit_sat = chainparams['dust_limit']['satoshis']
+    req.chainparams.max_funding_sat = chainparams['max_funding']['satoshis']
+    req.chainparams.max_payment_msat = \
+        chainparams['max_payment']['millisatoshis']
+    req.chainparams.when_lightning_became_cool = \
+        chainparams['when_lightning_became_cool']
+    req.chainparams.p2pkh_version = chainparams['p2pkh_version']
+    req.chainparams.p2sh_version = chainparams['p2sh_version']
+    req.chainparams.testnet = chainparams['testnet']
+    req.chainparams.bip32_key_version.pubkey_version = \
+        chainparams['bip32_key_version']['bip32_pubkey_version']
+    req.chainparams.bip32_key_version.privkey_version = \
+        chainparams['bip32_key_version']['bip32_privkey_version']
+    req.chainparams.is_elements = chainparams['is_elements']
+    if chainparams['fee_asset_tag']:
+        req.chainparams.fee_asset_tag = chainparams['fee_asset_tag']
+
+    # HACK: send the secret instead of generating on the HSM
+    req.hsm_secret = hsm_secret
+    
+    rsp = stub.InitHSM(req)
+    node_id = rsp.self_node_id
+    debug("PYHSMD init_hsm =>", node_id.hex())
+
+# message 10
+@stdout_exceptions
+def handle_get_channel_basepoints(self_id, peer_id, dbid):
+    global stub
+    debug("PYHSMD handle_get_channel_basepoints", self_id['k'].hex(), locals())
+    
+    
+# message 1
+@stdout_exceptions
+def handle_ecdh(self_id, point):
+    global stub
+    debug("PYHSMD handle_ecdh", self_id['k'].hex(), locals())
+
+    req = ECDHReq()
+    req.self_node_id = self_id['k']
+    req.point = point['pubkey']
+    rsp = stub.ECDH(req)
+    ss = rsp.shared_secret
+    debug("PYHSMD handle_ecdh =>", ss.hex())
+    return ss
+
+# message 9
+@stdout_exceptions
+def handle_pass_client_hsmfd(self_id, peer_id, dbid, capabilities):
+    global stub
+    debug("PYHSMD handle_pass_client_hsmfd", self_id['k'].hex(), locals())
+    
+    req = PassClientHSMFdReq()
+    req.self_node_id = self_id['k']
+    req.channel_nonce = peer_id['k'] + struct.pack("<Q", dbid)
+    req.capabilities = capabilities
+    rsp = stub.PassClientHSMFd(req)
+
+    return None
+    
+# message 18
+@stdout_exceptions
+def handle_get_per_commitment_point(self_id, peer_id, dbid, n):
+    global stub
+    debug("PYHSMD handle_get_per_commitment_point", self_id['k'].hex(), locals())
+    
+    req = GetPerCommitmentPointReq()
+    req.self_node_id = self_id['k']
+    req.channel_nonce = peer_id['k'] + struct.pack("<Q", dbid)
+    req.n = n
+    rsp = stub.GetPerCommitmentPoint(req)
+    return rsp.per_commitment_point, rsp.old_secret
+
+# message 2
+@stdout_exceptions
+def handle_cannouncement_sig(self_id, ca, node_id, dbid):
+    global stub
+    debug("PYHSMD handle_cannouncement_sig", self_id['k'].hex(), locals())
+
+# message 7
+@stdout_exceptions
+def handle_sign_withdrawal_tx(self_id, peer_id, dbid,
+                              satoshi_out,
+                              change_out,
+                              change_keyindex,
+                              outputs,
+                              utxos,
+                              tx):
+    global stub
+    debug("PYHSMD handle_sign_withdrawal_tx", self_id['k'].hex(), locals())
+
+    assert len(outputs) == 1, "expected a single output"
+    req = create_withdrawal_tx(self_id, tx, utxos, change_keyindex, outputs[0], change_out)
+    req.channel_nonce = peer_id['k'] + struct.pack("<Q", dbid)
+
+    debug("PYHSMD handle_sign_withdrawal_tx calling server")
+    rsp = stub.SignWithdrawalTx(req)
+    debug(rsp)
+    
+    # Remove unnecessary object derefs.
+    sigs = [sig.item for sig in rsp.sigs]
+
+    debug(sigs)
+    
+    for ndx, sig in enumerate(sigs):
+        debug("PYHSMD handle_sign_withdrawal_tx sig", ndx,
+              [elem.hex() for elem in sig])
+
+    return sigs
+
+def create_withdrawal_tx(self_id, tx, utxos, change_keyindex,
+                         output, change_output):
+    req = SignWithdrawalTxReq()
+    req.self_node_id = self_id['k']
+    version = tx['wally_tx']['version']
+    isds = []
+    txs_in = []
+    for i, inp in enumerate(tx['wally_tx']['inputs']):
+        txs_in.append(Tx.TxIn(inp['txhash'],
+                              inp['index'],
+                              inp['script'],
+                              inp['sequence']))
+        utxo = utxos[i]
+        assert not utxo['is_p2sh']
+        desc = SignDescriptor()
+        desc.key_loc.key_index = utxo['keyindex']
+        desc.key_loc.key_family = KeyLocator.layer_one
+        desc.output.value = utxo['amount']['satoshis']
+        isds.append(desc)
+    osds = []
+    txs_out = []
+    for out in tx['wally_tx']['outputs']:
+        txs_out.append(Tx.TxOut(out['satoshi'],
+                                out['script']))
+        desc = SignDescriptor()
+        if out['script'] != output['script']:
+            assert out['satoshi'] == change_output['satoshis']
+            desc.key_loc.key_index = change_keyindex
+            desc.key_loc.key_family = KeyLocator.layer_one
+        else:
+            desc.key_loc.key_family = KeyLocator.unknown
+        osds.append(desc)
+    tx = Tx(version, txs_in, txs_out)
+    debug("PYHSMD handle_sign_withdrawal_tx TX", tx.as_hex())
+    req.raw_tx_bytes = tx.as_bin()
+    req.input_descs.extend(isds)
+    req.output_descs.extend(osds)
+    return req
+
+# message 19
+@stdout_exceptions
+def handle_sign_remote_commitment_tx(self_id, tx,
+                                     remote_funding_pubkey,
+                                     funding, peer_id, dbid,
+                                     output_witscripts, remote_per_commit,
+                                     option_static_remotekey):
+    global stub
+    debug("PYHSMD handle_sign_remote_commitment_tx", self_id['k'].hex(), locals())
+
+    req = SignRemoteCommitmentTxReq()
+    req.self_node_id = self_id['k']
+    req.channel_nonce = peer_id['k'] + struct.pack("<Q", dbid)
+    req.remote_funding_pubkey = remote_funding_pubkey['pubkey']
+    req.remote_percommit_point = remote_per_commit['pubkey']
+    req.option_static_remotekey = option_static_remotekey
+    for witscript in output_witscripts:
+        if witscript:
+            req.output_witscripts.append(witscript)
+        else:
+            req.output_witscripts.append(b'')
+    version = tx['wally_tx']['version']
+    isds = []
+    txs_in = []
+    for i, inp in enumerate(tx['wally_tx']['inputs']):
+        txs_in.append(Tx.TxIn(inp['txhash'],
+                              inp['index'],
+                              inp['script'],
+                              inp['sequence']))
+        desc = SignDescriptor()
+        desc.output.value = funding['satoshis']
+        isds.append(desc)
+    osds = []
+    txs_out = []
+    for out in tx['wally_tx']['outputs']:
+        txs_out.append(Tx.TxOut(out['satoshi'],
+                                out['script']))
+        # FIXME - figure out the output SignDescriptor.
+        desc = SignDescriptor()
+        osds.append(desc)
+    tx = Tx(version, txs_in, txs_out, tx['wally_tx']['locktime'])
+    debug("PYHSMD handle_sign_remote_commitment_tx TX", tx.as_hex())
+    req.raw_tx_bytes = tx.as_bin()
+    req.input_descs.extend(isds)
+    req.output_descs.extend(osds)
+
+    rsp = stub.SignRemoteCommitmentTx(req)
+    debug(rsp)
+
+    # Remove unnecessary object derefs.
+    sigs = [sig.item for sig in rsp.sigs]
+
+    debug(sigs)
+    
+    for ndx, sig in enumerate(sigs):
+        debug("PYHSMD handle_sign_remote_commitment_tx sig", ndx,
+              [elem.hex() for elem in sig])
+
+    return sigs
+        
+# message 20
+@stdout_exceptions
+def handle_sign_remote_htlc_tx(self_id, tx, wscript,
+                               remote_per_commit_point,
+                               peer_id, dbid):
+    global stub
+    debug("PYHSMD handle_sign_remote_htlc_tx", self_id['k'].hex(), locals())
+
+    req = SignRemoteHTLCTxReq()
+    req.self_node_id = self_id['k']
+    req.channel_nonce = peer_id['k'] + struct.pack("<Q", dbid)
+    req.remote_per_commit_point = remote_per_commit_point['pubkey']
+    if wscript:
+        req.wscript = wscript
+    version = tx['wally_tx']['version']
+    isds = []
+    txs_in = []
+    for i, inp in enumerate(tx['wally_tx']['inputs']):
+        txs_in.append(Tx.TxIn(inp['txhash'],
+                              inp['index'],
+                              inp['script'],
+                              inp['sequence']))
+        # FIXME - figure out the input SignDescriptor.
+        desc = SignDescriptor()
+        isds.append(desc)
+    osds = []
+    txs_out = []
+    for out in tx['wally_tx']['outputs']:
+        txs_out.append(Tx.TxOut(out['satoshi'],
+                                out['script']))
+        # FIXME - figure out the output SignDescriptor.
+        desc = SignDescriptor()
+        osds.append(desc)
+    tx = Tx(version, txs_in, txs_out)
+    debug("PYHSMD handle_sign_remote_commitment_tx TX", tx.as_hex())
+    req.raw_tx_bytes = tx.as_bin()
+    req.input_descs.extend(isds)
+    req.output_descs.extend(osds)
+
+    rsp = stub.SignRemoteHTLCTx(req)
+    ## FIXME - temporary hack
+    #sigs = rsp.raw_sigs
+    sigs = []
+
+    for ndx, sig in enumerate(sigs):
+        debug("PYHSMD handle_sign_remote_htlc_tx sig", ndx, sig.hex())
+
+# message 21
+@stdout_exceptions
+def handle_sign_mutual_close_tx(self_id, tx,
+                                remote_funding_pubkey,
+                                funding, peer_id, dbid):
+    global stub
+    debug("PYHSMD handle_sign_mutual_close_tx", self_id['k'].hex(), locals())
+
+    req = SignMutualCloseTxReq()
+    req.self_node_id = self_id['k']
+    req.channel_nonce = peer_id['k'] + struct.pack("<Q", dbid)
+    req.remote_funding_pubkey = remote_funding_pubkey['pubkey']
+    version = tx['wally_tx']['version']
+    isds = []
+    txs_in = []
+    for i, inp in enumerate(tx['wally_tx']['inputs']):
+        txs_in.append(Tx.TxIn(inp['txhash'],
+                              inp['index'],
+                              inp['script'],
+                              inp['sequence']))
+        # FIXME - figure out the input SignDescriptor.
+        desc = SignDescriptor()
+        isds.append(desc)
+    osds = []
+    txs_out = []
+    for out in tx['wally_tx']['outputs']:
+        txs_out.append(Tx.TxOut(out['satoshi'],
+                                out['script']))
+        # FIXME - figure out the output SignDescriptor.
+        desc = SignDescriptor()
+        osds.append(desc)
+    tx = Tx(version, txs_in, txs_out)
+    debug("PYHSMD handle_sign_mutual_close_tx TX", tx.as_hex())
+    req.raw_tx_bytes = tx.as_bin()
+    req.input_descs.extend(isds)
+    req.output_descs.extend(osds)
+
+    rsp = stub.SignMutualCloseTx(req)
+    ## FIXME - temporary hack
+    #sigs = rsp.raw_sigs
+    sigs = []
+
+    for ndx, sig in enumerate(sigs):
+        debug("PYHSMD handle_sign_mutual_close_tx sig", ndx, sig.hex())
+
+# message 3
+# FIXME - fill in signature
+@stdout_exceptions
+def handle_channel_update_sig():
+    global stub
+    debug("PYHSMD handle_channel_update_sig", locals())

--- a/hsmd/hsmd.py
+++ b/hsmd/hsmd.py
@@ -265,7 +265,6 @@ def handle_sign_remote_commitment_tx(self_id, tx,
     for out in tx['wally_tx']['outputs']:
         txs_out.append(Tx.TxOut(out['satoshi'],
                                 out['script']))
-        # FIXME - figure out the output SignDescriptor.
         desc = SignDescriptor()
         osds.append(desc)
     tx = Tx(version, txs_in, txs_out, tx['wally_tx']['locktime'])

--- a/hsmd/py_hsmd.c
+++ b/hsmd/py_hsmd.c
@@ -1,0 +1,341 @@
+#include <hsmd/py_hsmd.h>
+#include <hsmd/py_types.h>
+
+struct node_id self_node_id;
+
+/*~ Python function objects. */
+static struct {
+	PyObject *setup;
+	PyObject *init_hsm;
+	PyObject *handle_pass_client_hsmfd;
+	PyObject *handle_ecdh;
+	PyObject *handle_get_channel_basepoints;
+	PyObject *handle_get_per_commitment_point;
+	PyObject *handle_cannouncement_sig;
+	PyObject *handle_sign_withdrawal_tx;
+	PyObject *handle_sign_remote_commitment_tx;
+	PyObject *handle_sign_remote_htlc_tx;
+	PyObject *handle_sign_mutual_close_tx;
+} pyfunc;
+
+void py_init_hsm(struct bip32_key_version *bip32_key_version,
+		 struct chainparams const *chainparams,
+		 struct secret *hsm_encryption_key,
+		 struct privkey *privkey,
+		 struct secret *seed,
+		 struct secrets *secrets,
+		 struct sha256 *shaseed,
+		 struct secret *hsm_secret)
+{
+	size_t ndx = 0;
+	PyObject *pargs = PyTuple_New(8);
+	PyTuple_SetItem(pargs, ndx++, py_bip32_key_version(bip32_key_version));
+	PyTuple_SetItem(pargs, ndx++, py_chainparams(chainparams));
+	PyTuple_SetItem(pargs, ndx++, hsm_encryption_key ?
+			py_secret(hsm_encryption_key): py_none());
+	PyTuple_SetItem(pargs, ndx++,
+			privkey ? py_privkey(privkey) : py_none());
+	PyTuple_SetItem(pargs, ndx++, seed ? py_secret(seed) : py_none());
+	PyTuple_SetItem(pargs, ndx++,
+			secrets ? py_secrets(secrets) : py_none());
+	PyTuple_SetItem(pargs, ndx++,
+			shaseed ? py_sha256(shaseed) : py_none());
+	PyTuple_SetItem(pargs, ndx++, py_secret(hsm_secret));
+	PyObject *pretval = PyObject_CallObject(pyfunc.init_hsm, pargs);
+	if (pretval == NULL) {
+		PyErr_Print();
+		status_failed(STATUS_FAIL_INTERNAL_ERROR, "%s:%d %s failed",
+			      __FILE__, __LINE__, __FUNCTION__);
+	}
+	Py_DECREF(pretval);
+
+	/* FIXME - Need to return something here */
+}
+
+bool py_handle_ecdh(struct pubkey *point, struct secret *o_ss)
+{
+	size_t ndx = 0;
+	PyObject *pargs = PyTuple_New(2);
+	PyTuple_SetItem(pargs, ndx++, py_node_id(&self_node_id));
+	PyTuple_SetItem(pargs, ndx++, py_pubkey(point));
+	PyObject *pretval = PyObject_CallObject(pyfunc.handle_ecdh, pargs);
+	if (pretval == NULL) {
+		PyErr_Print();
+		status_failed(STATUS_FAIL_INTERNAL_ERROR, "%s:%d %s failed",
+			      __FILE__, __LINE__, __FUNCTION__);
+		return false;	// not reached
+	}
+	// None will get returned if the input was bad.  Caller will
+	// do the status_broken.
+	if (!PyBytes_Check(pretval)) {
+		status_debug("%s:%d %s: bad return type",
+			     __FILE__, __LINE__, __FUNCTION__);
+		Py_DECREF(pretval);
+		return false;
+	}
+	if (PyBytes_Size(pretval) != sizeof(o_ss->data)) {
+		status_debug("%s:%d %s: bad return size",
+			     __FILE__, __LINE__, __FUNCTION__);
+		Py_DECREF(pretval);
+		return false;
+	}
+	memcpy(o_ss->data, PyBytes_AsString(pretval), sizeof(o_ss->data));
+	Py_DECREF(pretval);
+	return true;
+}
+
+void py_handle_cannouncement_sig(u8 *ca, size_t calen,
+				 struct node_id *node_id,
+				 u64 dbid)
+{
+	size_t ndx = 0;
+	PyObject *pargs = PyTuple_New(4);
+	PyTuple_SetItem(pargs, ndx++, py_node_id(&self_node_id));
+	PyTuple_SetItem(pargs, ndx++,
+			PyBytes_FromStringAndSize((char const *) ca, calen));
+	PyTuple_SetItem(pargs, ndx++, py_node_id(node_id));
+	PyTuple_SetItem(pargs, ndx++, PyLong_FromUnsignedLongLong(dbid));
+	PyObject *pretval =
+		PyObject_CallObject(pyfunc.handle_cannouncement_sig, pargs);
+	if (pretval == NULL) {
+		PyErr_Print();
+		status_failed(STATUS_FAIL_INTERNAL_ERROR, "%s:%d %s failed",
+			      __FILE__, __LINE__, __FUNCTION__);
+	}
+	Py_DECREF(pretval);
+
+	/* FIXME - Need to return something here */
+}
+
+void py_handle_get_channel_basepoints(struct node_id *peer_id, u64 dbid)
+{
+	size_t ndx = 0;
+	PyObject *pargs = PyTuple_New(3);
+	PyTuple_SetItem(pargs, ndx++, py_node_id(&self_node_id));
+	PyTuple_SetItem(pargs, ndx++, py_node_id(peer_id));
+	PyTuple_SetItem(pargs, ndx++, PyLong_FromUnsignedLongLong(dbid));
+	PyObject *pretval =
+		PyObject_CallObject(
+			pyfunc.handle_get_channel_basepoints, pargs);
+	if (pretval == NULL) {
+		PyErr_Print();
+		status_failed(STATUS_FAIL_INTERNAL_ERROR, "%s:%d %s failed",
+			      __FILE__, __LINE__, __FUNCTION__);
+	}
+	Py_DECREF(pretval);
+
+	/* FIXME - Need to return something here */
+}
+
+void py_handle_sign_remote_commitment_tx(
+	struct bitcoin_tx *tx,
+	struct pubkey *remote_funding_pubkey,
+	struct amount_sat *funding,
+	struct node_id *peer_id,
+	u64 dbid,
+	struct witscript const **output_witscripts,
+	struct pubkey *remote_per_commit,
+	bool option_static_remotekey,
+	u8 ****o_sigs)
+{
+	size_t ndx = 0;
+	PyObject *pargs = PyTuple_New(9);
+	PyTuple_SetItem(pargs, ndx++, py_node_id(&self_node_id));
+	PyTuple_SetItem(pargs, ndx++, py_bitcoin_tx(tx));
+	PyTuple_SetItem(pargs, ndx++, py_pubkey(remote_funding_pubkey));
+	PyTuple_SetItem(pargs, ndx++, py_amount_sat(funding));
+	PyTuple_SetItem(pargs, ndx++, py_node_id(peer_id));
+	PyTuple_SetItem(pargs, ndx++, PyLong_FromUnsignedLongLong(dbid));
+	PyTuple_SetItem(pargs, ndx++, py_witscripts(output_witscripts));
+	PyTuple_SetItem(pargs, ndx++, py_pubkey(remote_per_commit));
+	PyTuple_SetItem(pargs, ndx++, PyBool_FromLong(option_static_remotekey));
+	PyObject *pretval = PyObject_CallObject(
+		pyfunc.handle_sign_remote_commitment_tx, pargs);
+	py_return_sigs(__func__, pretval, o_sigs);
+}
+
+void py_handle_sign_remote_htlc_tx(
+	struct bitcoin_tx *tx,
+	u8 *wscript,
+	struct pubkey *remote_per_commit_point,
+	struct node_id *peer_id,
+	u64 dbid)
+{
+	size_t ndx = 0;
+	PyObject *pargs = PyTuple_New(6);
+	PyTuple_SetItem(pargs, ndx++, py_node_id(&self_node_id));
+	PyTuple_SetItem(pargs, ndx++, py_bitcoin_tx(tx));
+	PyTuple_SetItem(pargs, ndx++, wscript ?
+			PyBytes_FromStringAndSize((char const *) wscript,
+						  tal_bytelen(wscript)) :
+			py_none());
+	PyTuple_SetItem(pargs, ndx++, py_pubkey(remote_per_commit_point));
+	PyTuple_SetItem(pargs, ndx++, py_node_id(peer_id));
+	PyTuple_SetItem(pargs, ndx++, PyLong_FromUnsignedLongLong(dbid));
+	PyObject *pretval =
+		PyObject_CallObject(pyfunc.handle_sign_remote_htlc_tx, pargs);
+	if (pretval == NULL) {
+		PyErr_Print();
+		status_failed(STATUS_FAIL_INTERNAL_ERROR, "%s:%d %s failed",
+			      __FILE__, __LINE__, __FUNCTION__);
+	}
+	Py_DECREF(pretval);
+
+	/* FIXME - Need to return something here */
+}
+
+void py_handle_get_per_commitment_point(struct node_id *peer_id,
+					u64 dbid,
+					u64 n)
+{
+	size_t ndx = 0;
+	PyObject *pargs = PyTuple_New(4);
+	PyTuple_SetItem(pargs, ndx++, py_node_id(&self_node_id));
+	PyTuple_SetItem(pargs, ndx++, py_node_id(peer_id));
+	PyTuple_SetItem(pargs, ndx++, PyLong_FromUnsignedLongLong(dbid));
+	PyTuple_SetItem(pargs, ndx++, PyLong_FromUnsignedLongLong(n));
+	PyObject *pretval =
+		PyObject_CallObject(
+			pyfunc.handle_get_per_commitment_point, pargs);
+	if (pretval == NULL) {
+		PyErr_Print();
+		status_failed(STATUS_FAIL_INTERNAL_ERROR, "%s:%d %s failed",
+			      __FILE__, __LINE__, __FUNCTION__);
+	}
+	Py_XDECREF(pretval);
+
+	/* FIXME - Need to return something here */
+}
+
+void py_handle_sign_mutual_close_tx(
+	struct bitcoin_tx *tx,
+	struct pubkey *remote_funding_pubkey,
+	struct amount_sat *funding,
+	struct node_id *peer_id,
+	u64 dbid)
+{
+	size_t ndx = 0;
+	PyObject *pargs = PyTuple_New(6);
+	PyTuple_SetItem(pargs, ndx++, py_node_id(&self_node_id));
+	PyTuple_SetItem(pargs, ndx++, py_bitcoin_tx(tx));
+	PyTuple_SetItem(pargs, ndx++, py_pubkey(remote_funding_pubkey));
+	PyTuple_SetItem(pargs, ndx++, py_amount_sat(funding));
+	PyTuple_SetItem(pargs, ndx++, py_node_id(peer_id));
+	PyTuple_SetItem(pargs, ndx++, PyLong_FromUnsignedLongLong(dbid));
+	PyObject *pretval =
+		PyObject_CallObject(pyfunc.handle_sign_mutual_close_tx, pargs);
+	if (pretval == NULL) {
+		PyErr_Print();
+		status_failed(STATUS_FAIL_INTERNAL_ERROR, "%s:%d %s failed",
+			      __FILE__, __LINE__, __FUNCTION__);
+	}
+	Py_DECREF(pretval);
+
+	/* FIXME - Need to return something here */
+}
+
+void py_handle_pass_client_hsmfd(struct node_id *peer_id,
+				 u64 dbid,
+				 u64 capabilities)
+{
+	size_t ndx = 0;
+	PyObject *pargs = PyTuple_New(4);
+	PyTuple_SetItem(pargs, ndx++, py_node_id(&self_node_id));
+	PyTuple_SetItem(pargs, ndx++, py_node_id(peer_id));
+	PyTuple_SetItem(pargs, ndx++, PyLong_FromUnsignedLongLong(dbid));
+	PyTuple_SetItem(pargs, ndx++,
+			PyLong_FromUnsignedLongLong(capabilities));
+	PyObject *pretval =
+		PyObject_CallObject(pyfunc.handle_pass_client_hsmfd, pargs);
+	if (pretval == NULL) {
+		PyErr_Print();
+		status_failed(STATUS_FAIL_INTERNAL_ERROR, "%s:%d %s failed",
+			      __FILE__, __LINE__, __FUNCTION__);
+	}
+	Py_XDECREF(pretval);
+}
+
+void py_handle_sign_withdrawal_tx(
+	struct node_id *peer_id, u64 dbid,
+	struct amount_sat *satoshi_out,
+	struct amount_sat *change_out,
+	u32 change_keyindex,
+	struct bitcoin_tx_output **outputs,
+	struct utxo **utxos,
+	struct bitcoin_tx *tx,
+	u8 ****o_sigs)
+{
+	size_t ndx = 0;
+	PyObject *pargs = PyTuple_New(9);
+	PyTuple_SetItem(pargs, ndx++, py_node_id(&self_node_id));
+	PyTuple_SetItem(pargs, ndx++, py_node_id(peer_id));
+	PyTuple_SetItem(pargs, ndx++, PyLong_FromUnsignedLongLong(dbid));
+	PyTuple_SetItem(pargs, ndx++, py_amount_sat(satoshi_out));
+	PyTuple_SetItem(pargs, ndx++, py_amount_sat(change_out));
+	PyTuple_SetItem(pargs, ndx++, PyLong_FromUnsignedLong(change_keyindex));
+	PyTuple_SetItem(pargs, ndx++, py_bitcoin_tx_outputs(outputs));
+	PyTuple_SetItem(pargs, ndx++, py_utxos(utxos));
+	PyTuple_SetItem(pargs, ndx++, py_bitcoin_tx(tx));
+	PyObject *pretval =
+		PyObject_CallObject(pyfunc.handle_sign_withdrawal_tx, pargs);
+	py_return_sigs(__func__, pretval, o_sigs);
+}
+
+static PyObject *python_function(PyObject *pmodule, char *funcname)
+{
+	PyObject *pfunc = PyObject_GetAttrString(pmodule, funcname);
+	if (pfunc == NULL || !PyCallable_Check(pfunc)) {
+		if (PyErr_Occurred())
+			PyErr_Print();
+		status_failed(STATUS_FAIL_INTERNAL_ERROR,
+			      "%s:%d %s cannot find function \"%s\"",
+			      __FILE__, __LINE__, __FUNCTION__, funcname);
+	}
+	return pfunc;
+}
+
+void setup_python_functions(void)
+{
+	Py_Initialize();
+	PyObject *pname = PyUnicode_DecodeFSDefault("hsmd");
+	PyObject *pmodule = PyImport_Import(pname);
+	Py_DECREF(pname);
+	if (pmodule == NULL) {
+		PyErr_Print();
+		status_failed(STATUS_FAIL_INTERNAL_ERROR,
+			      "%s:%d %s failed tp load \"hsmd\"",
+			      __FILE__, __LINE__, __FUNCTION__);
+	}
+
+	pyfunc.setup = python_function(pmodule, "setup");
+	pyfunc.init_hsm = python_function(pmodule, "init_hsm");
+	pyfunc.handle_pass_client_hsmfd =
+		python_function(pmodule, "handle_pass_client_hsmfd");
+	pyfunc.handle_ecdh = python_function(pmodule, "handle_ecdh");
+	pyfunc.handle_get_channel_basepoints =
+		python_function(pmodule, "handle_get_channel_basepoints");
+	pyfunc.handle_get_per_commitment_point =
+		python_function(pmodule, "handle_get_per_commitment_point");
+	pyfunc.handle_cannouncement_sig =
+		python_function(pmodule, "handle_cannouncement_sig");
+	pyfunc.handle_sign_withdrawal_tx =
+		python_function(pmodule, "handle_sign_withdrawal_tx");
+	pyfunc.handle_sign_remote_commitment_tx =
+		python_function(pmodule, "handle_sign_remote_commitment_tx");
+	pyfunc.handle_sign_remote_htlc_tx =
+		python_function(pmodule, "handle_sign_remote_htlc_tx");
+	pyfunc.handle_sign_mutual_close_tx =
+		python_function(pmodule, "handle_sign_mutual_close_tx");
+
+	Py_DECREF(pmodule);
+
+	/* Call the python setup function. */
+	PyObject *pretval = PyObject_CallObject(pyfunc.setup, NULL);
+	if (pretval == NULL) {
+		PyErr_Print();
+		status_failed(STATUS_FAIL_INTERNAL_ERROR,
+			      "%s:%d %s python setup failed",
+			      __FILE__, __LINE__, __FUNCTION__);
+	}
+	Py_DECREF(pretval);
+}

--- a/hsmd/py_hsmd.h
+++ b/hsmd/py_hsmd.h
@@ -1,0 +1,73 @@
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#include <bitcoin/chainparams.h>
+#include <bitcoin/tx.h>
+#include <common/derive_basepoints.h>
+#include <common/utxo.h>
+#include <common/node_id.h>
+#include <ccan/crypto/sha256/sha256.h>
+
+extern struct node_id self_node_id;
+
+void py_init_hsm(struct bip32_key_version *bip32_key_version,
+		 struct chainparams const *chainparams,
+		 struct secret *hsm_encryption_key,
+		 struct privkey *privkey,
+		 struct secret *seed,
+		 struct secrets *secrets,
+		 struct sha256 *shaseed,
+		 struct secret *hsm_secret);
+
+bool py_handle_ecdh(struct pubkey *point, struct secret *o_ss);
+
+void py_handle_cannouncement_sig(u8 *ca, size_t calen,
+				 struct node_id *node_id,
+				 u64 dbid);
+
+void py_handle_get_channel_basepoints(struct node_id *peer_id, u64 dbid);
+
+void py_handle_sign_remote_commitment_tx(
+	struct bitcoin_tx *tx,
+	struct pubkey *remote_funding_pubkey,
+	struct amount_sat *funding,
+	struct node_id *peer_id,
+	u64 dbid,
+	struct witscript const **output_witscripts,
+	struct pubkey *remote_per_commit,
+	bool option_static_remotekey,
+	u8 ****o_sigs);
+
+void py_handle_sign_remote_htlc_tx(
+	struct bitcoin_tx *tx,
+	u8 *wscript,
+	struct pubkey *remote_per_commit_point,
+	struct node_id *peer_id,
+	u64 dbid);
+
+void py_handle_get_per_commitment_point(struct node_id *peer_id,
+					u64 dbid,
+					u64 n);
+
+void py_handle_sign_mutual_close_tx(
+	struct bitcoin_tx *tx,
+	struct pubkey *remote_funding_pubkey,
+	struct amount_sat *funding,
+	struct node_id *peer_id,
+	u64 dbid);
+
+void py_handle_pass_client_hsmfd(struct node_id *peer_id,
+				 u64 dbid,
+				 u64 capabilities);
+
+void py_handle_sign_withdrawal_tx(
+	struct node_id *peer_id, u64 dbid,
+	struct amount_sat *satoshi_out,
+	struct amount_sat *change_out,
+	u32 change_keyindex,
+	struct bitcoin_tx_output **outputs,
+	struct utxo **utxos,
+	struct bitcoin_tx *tx,
+	u8 ****o_sigs);
+
+void setup_python_functions(void);

--- a/hsmd/py_types.c
+++ b/hsmd/py_types.c
@@ -1,0 +1,404 @@
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#include <hsmd/py_types.h>
+
+PyObject *py_none(void)
+{
+	Py_RETURN_NONE;
+}
+
+PyObject *py_bip32_key_version(struct bip32_key_version const *vp)
+{
+	PyObject *pdict = PyDict_New();
+	PyDict_SetItemString(pdict, "bip32_pubkey_version",
+			     PyLong_FromLong(vp->bip32_pubkey_version));
+	PyDict_SetItemString(pdict, "bip32_privkey_version",
+			     PyLong_FromLong(vp->bip32_privkey_version));
+	return pdict;
+}
+
+PyObject *py_sha256(struct sha256 const *sp)
+{
+	return PyBytes_FromStringAndSize((char const *) sp->u.u8, 32);
+}
+
+PyObject *py_sha256_double(struct sha256_double const *sp)
+{
+	PyObject *pdict = PyDict_New();
+	PyDict_SetItemString(pdict, "sha", py_sha256(&(sp->sha)));
+	return pdict;
+}
+
+PyObject *py_witscript(struct witscript const *pp)
+{
+	return pp->ptr ?
+		PyBytes_FromStringAndSize(
+			(char const *) pp->ptr, tal_count(pp->ptr)) :
+		py_none();
+}
+
+PyObject *py_witscripts(struct witscript const **witscripts)
+{
+	size_t len = tal_count(witscripts);
+	PyObject *plist = PyList_New(len);
+	for (size_t ii = 0; ii < len; ++ii)
+		PyList_SetItem(plist, ii, py_witscript(witscripts[ii]));
+	return plist;
+}
+
+PyObject *py_bitcoin_blkid(struct bitcoin_blkid const *bp)
+{
+	PyObject *pdict = PyDict_New();
+	PyDict_SetItemString(pdict, "shad", py_sha256_double(&(bp->shad)));
+	return pdict;
+}
+
+PyObject *py_bitcoin_txid(struct bitcoin_txid const *bp)
+{
+	PyObject *pdict = PyDict_New();
+	PyDict_SetItemString(pdict, "shad", py_sha256_double(&(bp->shad)));
+	return pdict;
+}
+
+PyObject *py_amount_sat(struct amount_sat const *ap)
+{
+	PyObject *pdict = PyDict_New();
+	PyDict_SetItemString(pdict, "satoshis",
+			     PyLong_FromUnsignedLongLong(ap->satoshis));
+	return pdict;
+}
+
+PyObject *py_amount_msat(struct amount_msat const *ap)
+{
+	PyObject *pdict = PyDict_New();
+	PyDict_SetItemString(pdict, "millisatoshis",
+			     PyLong_FromUnsignedLongLong(ap->millisatoshis));
+	return pdict;
+}
+
+PyObject *py_chainparams(struct chainparams const *cp)
+{
+	PyObject *pdict = PyDict_New();
+	PyDict_SetItemString(pdict, "network_name",
+			     PyUnicode_FromString(cp->network_name));
+	PyDict_SetItemString(pdict, "bip173_name",
+			     PyUnicode_FromString(cp->bip173_name));
+	PyDict_SetItemString(pdict, "bip70_name",
+			     PyUnicode_FromString(cp->bip70_name));
+	PyDict_SetItemString(pdict, "genesis_blockhash",
+			     py_bitcoin_blkid(&(cp->genesis_blockhash)));
+	PyDict_SetItemString(pdict, "rpc_port",
+			     PyLong_FromLong(cp->rpc_port));
+	PyDict_SetItemString(pdict, "cli",
+			     PyUnicode_FromString(cp->cli));
+	PyDict_SetItemString(pdict, "cli_args",
+			     PyUnicode_FromString(cp->cli_args));
+	PyDict_SetItemString(pdict, "cli_min_supported_version",
+			     PyLong_FromUnsignedLongLong(
+				     cp->cli_min_supported_version));
+	PyDict_SetItemString(pdict, "dust_limit",
+			     py_amount_sat(&(cp->dust_limit)));
+	PyDict_SetItemString(pdict, "max_funding",
+			     py_amount_sat(&(cp->max_funding)));
+	PyDict_SetItemString(pdict, "max_payment",
+			     py_amount_msat(&(cp->max_payment)));
+	PyDict_SetItemString(pdict, "when_lightning_became_cool",
+			     PyLong_FromUnsignedLong(
+				     cp->when_lightning_became_cool));
+	PyDict_SetItemString(pdict, "p2pkh_version",
+			     PyLong_FromUnsignedLong(cp->p2pkh_version));
+	PyDict_SetItemString(pdict, "p2sh_version",
+			     PyLong_FromUnsignedLong(cp->p2sh_version));
+	PyDict_SetItemString(pdict, "testnet",
+			     PyBool_FromLong(cp->testnet));
+	PyDict_SetItemString(pdict, "bip32_key_version",
+			     py_bip32_key_version(&(cp->bip32_key_version)));
+	PyDict_SetItemString(pdict, "is_elements",
+			     PyBool_FromLong(cp->is_elements));
+	PyDict_SetItemString(pdict, "fee_asset_tag",
+			     cp->fee_asset_tag ?
+			     PyBytes_FromStringAndSize
+			     ((char const *) cp->fee_asset_tag, 33) :
+			     py_none());
+	return pdict;
+}
+
+PyObject *py_node_id(struct node_id *pp)
+{
+	PyObject *pdict = PyDict_New();
+	PyDict_SetItemString(pdict, "k",
+			     PyBytes_FromStringAndSize(
+				     (char const *) pp->k, PUBKEY_CMPR_LEN));
+	return pdict;
+}
+
+PyObject *py_secp256k1_pubkey(secp256k1_pubkey *kp)
+{
+	return PyBytes_FromStringAndSize((char const *) kp->data, 64);
+}
+
+PyObject *py_secret(struct secret *sp)
+{
+	return PyBytes_FromStringAndSize((char const *) sp->data, 32);
+}
+
+PyObject *py_privkey(struct privkey *kp)
+{
+	PyObject *pdict = PyDict_New();
+	PyDict_SetItemString(pdict, "secret", py_secret(&(kp->secret)));
+	return pdict;
+}
+
+PyObject *py_pubkey(struct pubkey *kp)
+{
+	PyObject *pdict = PyDict_New();
+	PyDict_SetItemString(pdict, "pubkey",
+			     py_secp256k1_pubkey(&(kp->pubkey)));
+	return pdict;
+}
+
+PyObject *py_secrets(struct secrets *sp)
+{
+	PyObject *pdict = PyDict_New();
+	PyDict_SetItemString(pdict, "funding_privkey",
+			     py_privkey(&(sp->funding_privkey)));
+	PyDict_SetItemString(pdict, "revocation_basepoint_secret",
+			     py_secret(&(sp->revocation_basepoint_secret)));
+	PyDict_SetItemString(pdict, "payment_basepoint_secret",
+			     py_secret(&(sp->payment_basepoint_secret)));
+	PyDict_SetItemString(pdict, "htlc_basepoint_secret",
+			     py_secret(&(sp->htlc_basepoint_secret)));
+	PyDict_SetItemString(pdict, "delayed_payment_basepoint_secret",
+			     py_secret(
+				     &(sp->delayed_payment_basepoint_secret)));
+	return pdict;
+}
+
+PyObject *py_unilateral_close_info(struct unilateral_close_info *ip)
+{
+	PyObject *pdict = PyDict_New();
+	PyDict_SetItemString(pdict, "channel_id",
+			     PyLong_FromUnsignedLongLong(ip->channel_id));
+	PyDict_SetItemString(pdict, "node_id", py_node_id(&(ip->peer_id)));
+	PyDict_SetItemString(pdict, "commitment_point",
+			     ip->commitment_point ?
+			     py_pubkey(ip->commitment_point) :
+			     py_none());
+	return pdict;
+}
+
+PyObject *py_bitcoin_tx_output(struct bitcoin_tx_output *output)
+{
+	PyObject *pdict = PyDict_New();
+	PyDict_SetItemString(pdict, "amount", py_amount_sat(&(output->amount)));
+	PyDict_SetItemString(pdict, "script",
+			     PyBytes_FromStringAndSize(
+				     (char const *) output->script,
+				     tal_count(output->script)));
+	return pdict;
+}
+
+PyObject *py_bitcoin_tx_outputs(struct bitcoin_tx_output **outputs)
+{
+	size_t len = tal_count(outputs);
+	PyObject *plist = PyList_New(len);
+	for (size_t ii = 0; ii < len; ++ii)
+		PyList_SetItem(plist, ii, py_bitcoin_tx_output(outputs[ii]));
+	return plist;
+}
+
+PyObject *py_utxo(struct utxo *utxo)
+{
+	PyObject *pdict = PyDict_New();
+	PyDict_SetItemString(pdict, "txid", py_bitcoin_txid(&(utxo->txid)));
+	PyDict_SetItemString(pdict, "outnum",
+			     PyLong_FromUnsignedLong(utxo->outnum));
+	PyDict_SetItemString(pdict, "amount", py_amount_sat(&(utxo->amount)));
+	PyDict_SetItemString(pdict, "keyindex",
+			     PyLong_FromUnsignedLong(utxo->keyindex));
+	PyDict_SetItemString(pdict, "is_p2sh",
+			     PyBool_FromLong(utxo->is_p2sh ? 1 : 0));
+	PyDict_SetItemString(pdict, "close_info",
+			     utxo->close_info ?
+			     py_unilateral_close_info(utxo->close_info) :
+			     py_none());
+	/* status, blockheight, spendheight and scriptPubkey are not
+	   set in this context */
+	return pdict;
+}
+
+PyObject *py_utxos(struct utxo **utxos)
+{
+	size_t len = tal_count(utxos);
+	PyObject *plist = PyList_New(len);
+	for (size_t ii = 0; ii < len; ++ii)
+		PyList_SetItem(plist, ii, py_utxo(utxos[ii]));
+	return plist;
+}
+
+PyObject *py_amounts_sat(struct amount_sat **input_amounts)
+{
+	size_t len = tal_count(input_amounts);
+	PyObject *plist = PyList_New(len);
+	for (size_t ii = 0; ii < len; ++ii)
+		PyList_SetItem(plist, ii, input_amounts[ii] ?
+			       py_amount_sat(input_amounts[ii]) : py_none());
+	return plist;
+}
+
+PyObject *py_wally_tx_witness_items(struct wally_tx_witness_item *items,
+                                           size_t num_items)
+{
+	PyObject *plist = PyList_New(num_items);
+	for (size_t ii = 0; ii < num_items; ++ii)
+		PyList_SetItem(plist, ii,
+			       PyBytes_FromStringAndSize(
+				       (char const *) items[ii].witness,
+				       items[ii].witness_len));
+	return plist;
+}
+
+PyObject *py_wally_tx_witness_stack(struct wally_tx_witness_stack *pp)
+{
+	PyObject *pdict = PyDict_New();
+	PyDict_SetItemString(pdict, "items",
+			     py_wally_tx_witness_items(
+				     pp->items, pp->num_items));
+	PyDict_SetItemString(pdict, "items_allocation_len",
+			     PyLong_FromSize_t(pp->items_allocation_len));
+	return pdict;
+}
+
+PyObject *py_wally_tx_input(struct wally_tx_input const *pp)
+{
+	PyObject *pdict = PyDict_New();
+	PyDict_SetItemString(pdict, "txhash",
+			     PyBytes_FromStringAndSize(
+				     (char const *) pp->txhash,
+				     WALLY_TXHASH_LEN));
+	PyDict_SetItemString(pdict, "index",
+			     PyLong_FromUnsignedLong(pp->index));
+	PyDict_SetItemString(pdict, "sequence",
+			     PyLong_FromUnsignedLong(pp->sequence));
+	PyDict_SetItemString(pdict, "script",
+			     PyBytes_FromStringAndSize(
+				     (char const *) pp->script,
+				     pp->script_len));
+	PyDict_SetItemString(pdict, "witness",
+			     pp->witness
+			     ? py_wally_tx_witness_stack(pp->witness)
+			     : py_none());
+	PyDict_SetItemString(pdict, "features",
+			     PyLong_FromUnsignedLong(pp->features));
+	return pdict;
+}
+
+PyObject *py_wally_tx_inputs(struct wally_tx_input *inputs,
+                                    size_t num_inputs)
+{
+	PyObject *plist = PyList_New(num_inputs);
+	for (size_t ii = 0; ii < num_inputs; ++ii)
+		PyList_SetItem(plist, ii, py_wally_tx_input(&(inputs[ii])));
+	return plist;
+}
+
+PyObject *py_wally_tx_output(struct wally_tx_output const *pp)
+{
+	PyObject *pdict = PyDict_New();
+	PyDict_SetItemString(pdict, "satoshi",
+			     PyLong_FromUnsignedLongLong(pp->satoshi));
+	PyDict_SetItemString(pdict, "script",
+			     PyBytes_FromStringAndSize(
+				     (char const *) pp->script,
+				     pp->script_len));
+	PyDict_SetItemString(pdict, "features",
+			     PyLong_FromUnsignedLong(pp->features));
+	return pdict;
+}
+
+PyObject *py_wally_tx_outputs(struct wally_tx_output *outputs,
+                                     size_t num_outputs)
+{
+	PyObject *plist = PyList_New(num_outputs);
+	for (size_t ii = 0; ii < num_outputs; ++ii)
+		PyList_SetItem(plist, ii, py_wally_tx_output(&(outputs[ii])));
+	return plist;
+}
+
+PyObject *py_wally_tx(struct wally_tx const *pp)
+{
+	PyObject *pdict = PyDict_New();
+	PyDict_SetItemString(pdict, "version",
+			     PyLong_FromUnsignedLong(pp->version));
+	PyDict_SetItemString(pdict, "locktime",
+			     PyLong_FromUnsignedLong(pp->locktime));
+	PyDict_SetItemString(pdict, "inputs",
+			     py_wally_tx_inputs(pp->inputs, pp->num_inputs));
+	PyDict_SetItemString(pdict, "inputs_allocation_len",
+			     PyLong_FromSize_t(pp->inputs_allocation_len));
+	PyDict_SetItemString(pdict, "outputs",
+			     py_wally_tx_outputs(pp->outputs, pp->num_outputs));
+	PyDict_SetItemString(pdict, "outputs_allocation_len",
+			     PyLong_FromSize_t(pp->outputs_allocation_len));
+	return pdict;
+}
+
+PyObject *py_bitcoin_tx(struct bitcoin_tx const *pp)
+{
+	PyObject *pdict = PyDict_New();
+	PyDict_SetItemString(pdict, "input_amounts",
+			     py_amounts_sat(pp->input_amounts));
+	PyDict_SetItemString(pdict, "wally_tx", py_wally_tx(pp->wtx));
+	PyDict_SetItemString(pdict, "chainparams",
+			     py_chainparams(pp->chainparams));
+	return pdict;
+}
+
+void py_return_sigs(char const * func, PyObject *pretval, u8 ****o_sigs)
+{
+	if (pretval == NULL) {
+		PyErr_Print();
+		status_failed(STATUS_FAIL_INTERNAL_ERROR, "%s:%d %s failed",
+			      __FILE__, __LINE__, __FUNCTION__);
+	}
+	if (!PySequence_Check(pretval)) {
+		status_failed(STATUS_FAIL_INTERNAL_ERROR,
+			      "%s:%d %s bad return type",
+			      __FILE__, __LINE__, __FUNCTION__);
+		Py_DECREF(pretval);	// not reached
+	}
+	u8 ***sigs;
+	Py_ssize_t nsigs = PySequence_Length(pretval);
+	sigs = tal_arrz(tmpctx, u8**, nsigs);
+	for (size_t ii = 0; ii < nsigs; ++ii) {
+		PyObject *sig = PySequence_GetItem(pretval, ii);
+		if (!PySequence_Check(sig)) {
+			status_failed(STATUS_FAIL_INTERNAL_ERROR,
+				      "%s:%d %s bad sig type",
+				      __FILE__, __LINE__, __FUNCTION__);
+			Py_DECREF(sig);		// not reached
+			Py_DECREF(pretval);	// not reached
+		}
+		Py_ssize_t nelem = PySequence_Length(sig);
+		sigs[ii] = tal_arrz(sigs, u8*, nelem);
+		for (size_t jj = 0; jj < nelem; ++jj) {
+			PyObject *elem = PySequence_GetItem(sig, jj);
+			if (!PyBytes_Check(elem)) {
+				status_failed(STATUS_FAIL_INTERNAL_ERROR,
+					      "%s:%d %s bad elem type",
+					      __FILE__, __LINE__, __FUNCTION__);
+				Py_DECREF(elem);	// not reached
+				Py_DECREF(sig);		// not reached
+				Py_DECREF(pretval);	// not reached
+			}
+			size_t elen = PyBytes_Size(elem);
+			sigs[ii][jj] = tal_arr(sigs[ii], u8, elen);
+			memcpy(sigs[ii][jj], PyBytes_AsString(elem), elen);
+			Py_DECREF(elem);
+		}
+		Py_DECREF(sig);
+	}
+	Py_DECREF(pretval);
+	*o_sigs = sigs;
+}

--- a/hsmd/py_types.h
+++ b/hsmd/py_types.h
@@ -1,0 +1,46 @@
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#include <bitcoin/chainparams.h>
+#include <bitcoin/tx.h>
+#include <common/derive_basepoints.h>
+#include <common/node_id.h>
+#include <common/status.h>
+#include <common/utils.h>
+#include <common/utxo.h>
+
+PyObject *py_none(void);
+PyObject *py_bip32_key_version(struct bip32_key_version const *vp);
+PyObject *py_sha256(struct sha256 const *sp);
+PyObject *py_sha256_double(struct sha256_double const *sp);
+PyObject *py_witscript(struct witscript const *pp);
+PyObject *py_witscripts(struct witscript const **witscripts);
+PyObject *py_bitcoin_blkid(struct bitcoin_blkid const *bp);
+PyObject *py_bitcoin_txid(struct bitcoin_txid const *bp);
+PyObject *py_amount_sat(struct amount_sat const *ap);
+PyObject *py_amount_msat(struct amount_msat const *ap);
+PyObject *py_chainparams(struct chainparams const *cp);
+PyObject *py_node_id(struct node_id *pp);
+PyObject *py_secp256k1_pubkey(secp256k1_pubkey *kp);
+PyObject *py_secret(struct secret *sp);
+PyObject *py_privkey(struct privkey *kp);
+PyObject *py_pubkey(struct pubkey *kp);
+PyObject *py_secrets(struct secrets *sp);
+PyObject *py_unilateral_close_info(struct unilateral_close_info *ip);
+PyObject *py_bitcoin_tx_output(struct bitcoin_tx_output *output);
+PyObject *py_bitcoin_tx_outputs(struct bitcoin_tx_output **outputs);
+PyObject *py_utxo(struct utxo *utxo);
+PyObject *py_utxos(struct utxo **utxos);
+PyObject *py_amounts_sat(struct amount_sat **input_amounts);
+PyObject *py_wally_tx_witness_items(struct wally_tx_witness_item *items,
+				    size_t num_items);
+PyObject *py_wally_tx_witness_stack(struct wally_tx_witness_stack *pp);
+PyObject *py_wally_tx_input(struct wally_tx_input const *pp);
+PyObject *py_wally_tx_inputs(struct wally_tx_input *inputs, size_t num_inputs);
+PyObject *py_wally_tx_output(struct wally_tx_output const *pp);
+PyObject *py_wally_tx_outputs(struct wally_tx_output *outputs,
+			      size_t num_outputs);
+PyObject *py_wally_tx(struct wally_tx const *pp);
+PyObject *py_bitcoin_tx(struct bitcoin_tx const *pp);
+
+void py_return_sigs(char const * func, PyObject *pretval, u8 ****o_sigs);

--- a/hsmd/regen.sh
+++ b/hsmd/regen.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+python3 -m grpc_tools.protoc \
+        -I. \
+        --python_out=. \
+        --grpc_python_out=. \
+        api.proto

--- a/openingd/openingd.c
+++ b/openingd/openingd.c
@@ -704,10 +704,14 @@ static bool funder_finalize_channel_setup(struct state *state,
 	 * witness script.  It also needs the amount of the funding output,
 	 * as segwit signatures commit to that as well, even though it doesn't
 	 * explicitly appear in the transaction itself. */
-	msg = towire_hsm_sign_remote_commitment_tx(NULL,
-						   *tx,
-						   &state->channel->funding_pubkey[REMOTE],
-						   state->channel->funding);
+	msg = towire_hsm_sign_remote_commitment_tx(
+		NULL,
+		*tx,
+		&state->channel->funding_pubkey[REMOTE],
+		state->channel->funding,
+		(const struct witscript **) (*tx)->output_witscripts,
+		&state->first_per_commitment_point[REMOTE],
+		state->channel->option_static_remotekey);
 
 	wire_sync_write(HSM_FD, take(msg));
 	msg = wire_sync_read(tmpctx, HSM_FD);
@@ -1217,10 +1221,14 @@ static u8 *fundee_channel(struct state *state, const u8 *open_channel_msg)
 	}
 
 	/* Make HSM sign it */
-	msg = towire_hsm_sign_remote_commitment_tx(NULL,
-						   remote_commit,
-						   &state->channel->funding_pubkey[REMOTE],
-						   state->channel->funding);
+	msg = towire_hsm_sign_remote_commitment_tx(
+		NULL,
+		remote_commit,
+		&state->channel->funding_pubkey[REMOTE],
+		state->channel->funding,
+		(const struct witscript **) remote_commit->output_witscripts,
+		&state->first_per_commitment_point[REMOTE],
+		state->channel->option_static_remotekey);
 
 	wire_sync_write(HSM_FD, take(msg));
 	msg = wire_sync_read(tmpctx, HSM_FD);

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,0 +1,1 @@
+/hsmtool

--- a/tools/generate-wire.py
+++ b/tools/generate-wire.py
@@ -221,6 +221,7 @@ class Type(FieldSet):
         'per_peer_state',
         'bitcoin_tx_output',
         'exclude_entry',
+        'witscript',
     ]
 
     # Some BOLT types are re-typed based on their field name

--- a/wire/fromwire.c
+++ b/wire/fromwire.c
@@ -392,6 +392,19 @@ struct bitcoin_tx_output *fromwire_bitcoin_tx_output(const tal_t *ctx,
 	return output;
 }
 
+struct witscript *fromwire_witscript(const tal_t *ctx, const u8 **cursor, size_t *max)
+{
+	struct witscript *retval = tal(ctx, struct witscript);
+	u16 len = fromwire_u16(cursor, max);
+	if (len == 0) {
+		retval->ptr = NULL;
+	} else {
+		retval->ptr = tal_arr(retval, u8, len);
+		fromwire_u8_array(cursor, max, retval->ptr, len);
+	}
+	return retval;
+}
+
 void fromwire_chainparams(const u8 **cursor, size_t *max,
 			  const struct chainparams **chainparams)
 {

--- a/wire/towire.c
+++ b/wire/towire.c
@@ -257,6 +257,16 @@ void towire_bitcoin_tx_output(u8 **pptr, const struct bitcoin_tx_output *output)
 	towire_u8_array(pptr, output->script, tal_count(output->script));
 }
 
+void towire_witscript(u8 **pptr, const struct witscript *script)
+{
+	if (script == NULL || script->ptr == NULL) {
+		towire_u16(pptr, 0);
+	} else {
+		towire_u16(pptr, tal_count(script->ptr));
+		towire_u8_array(pptr, script->ptr, tal_count(script->ptr));
+	}
+}
+
 void towire_chainparams(u8 **cursor, const struct chainparams *chainparams)
 {
 	towire_bitcoin_blkid(cursor, &chainparams->genesis_blockhash);

--- a/wire/wire.h
+++ b/wire/wire.h
@@ -23,6 +23,7 @@ struct channel_id {
 /* Define channel_id_eq (no padding) */
 STRUCTEQ_DEF(channel_id, 0, id);
 
+struct witscript;
 struct bitcoin_blkid;
 struct bitcoin_signature;
 struct bitcoin_txid;
@@ -89,6 +90,7 @@ void towire_siphash_seed(u8 **cursor, const struct siphash_seed *seed);
 
 void towire_bip32_key_version(u8 **cursor, const struct bip32_key_version *version);
 void towire_bitcoin_tx_output(u8 **pptr, const struct bitcoin_tx_output *output);
+void towire_witscript(u8 **pptr, const struct witscript *script);
 void towire_chainparams(u8 **cursor, const struct chainparams *chainparams);
 
 const u8 *fromwire(const u8 **cursor, size_t *max, void *copy, size_t n);
@@ -142,7 +144,8 @@ void fromwire_bip32_key_version(const u8 **cursor, size_t *max,
 				struct bip32_key_version *version);
 struct bitcoin_tx_output *fromwire_bitcoin_tx_output(const tal_t *ctx,
 						     const u8 **cursor, size_t *max);
-
+struct witscript *fromwire_witscript(const tal_t *ctx,
+								 const u8 **cursor, size_t *max);
 void fromwire_chainparams(const u8 **cursor, size_t *max,
 			  const struct chainparams **chainparams);
 


### PR DESCRIPTION
# This PR is a proof-of-concept sketch of external message signing for c-lightning.

## Modifications to HSMD

The private keys and secrets are sequestered in an external program, the ["Lightning Policy Signer", (LiPoSig)](https://gitlab.com/ksedgwic/liposig).

This PoC proxies signing via a Python library and gRPC to the external signer.  Other approaches are available, including performing the gRPC call in C++ and eliminating the Python dependency.

In the current implementation, each of the message handlers in `hsmd.c` the arguments are converted to python objects and a call is made to a python proxy method.  The python method then submits the unsigned transaction to the external signer for signing via gRPC.

Original signing commented out, python proxy called instead:
https://github.com/ksedgwic/lightning-1/blob/8ae445775b09cacc95fb9cb1f180006a32dac5f9/hsmd/hsmd.c#L1067-L1091

Making gRPC call to remote `liposigd` and returning resulting signatures:
https://github.com/ksedgwic/lightning-1/blob/8ae445775b09cacc95fb9cb1f180006a32dac5f9/hsmd/hsmd.py#L231-L289

## Other Modifications

In order for the remote signer to completely verify the proposed transaction additional parameters (witness scripts and remote-per-commit) needed to be added to the `hsm_sign_remote_commitment_tx` message from `channeld` and `openingd`:
https://github.com/ksedgwic/lightning-1/blob/8ae445775b09cacc95fb9cb1f180006a32dac5f9/hsmd/hsm_wire.csv#L156-L164