### PR TITLE
Policy recompose

### DIFF
--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -840,10 +840,23 @@ static secp256k1_ecdsa_signature *calc_commitsigs(const tal_t *ctx,
 	const u8 *msg;
 	secp256k1_ecdsa_signature *htlc_sigs;
 
+	size_t num_entries = tal_count(htlc_map);
+	struct sha256 *rhashes = tal_arrz(tmpctx, struct sha256, num_entries);
+	size_t nrhash = 0;
+	for (size_t ndx = 0; ndx < num_entries; ++ndx) {
+		if (htlc_map[ndx]) {
+			memcpy(&rhashes[nrhash], &htlc_map[ndx]->rhash, sizeof(rhashes[nrhash]));
+			++nrhash;
+		}
+	}
+	tal_resize(&rhashes, nrhash);
+
 	msg = towire_hsm_sign_remote_commitment_tx(NULL, txs[0],
 						   &peer->channel->funding_pubkey[REMOTE],
 						   &peer->remote_per_commit,
-						   peer->channel->option_static_remotekey);
+						   peer->channel->option_static_remotekey,
+						   rhashes, commit_index,
+						   channel_feerate(peer->channel, REMOTE));
 
 	msg = hsm_req(tmpctx, take(msg));
 	if (!fromwire_hsm_sign_tx_reply(msg, commit_sig))

--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -855,8 +855,7 @@ static secp256k1_ecdsa_signature *calc_commitsigs(const tal_t *ctx,
 						   &peer->channel->funding_pubkey[REMOTE],
 						   &peer->remote_per_commit,
 						   peer->channel->option_static_remotekey,
-						   rhashes, commit_index,
-						   channel_feerate(peer->channel, REMOTE));
+						   rhashes, commit_index);
 
 	msg = hsm_req(tmpctx, take(msg));
 	if (!fromwire_hsm_sign_tx_reply(msg, commit_sig))

--- a/contrib/remote_hsmd/NOTES.md
+++ b/contrib/remote_hsmd/NOTES.md
@@ -86,4 +86,4 @@ Some popular tests:
 rust-lightning-signer
 ----------------------------------------------------------------
 
-    cargo run --bin server |& tee log3
+    cargo run --bin server -- --no-persist --test-mode |& tee log3

--- a/contrib/remote_hsmd/dump.cc
+++ b/contrib/remote_hsmd/dump.cc
@@ -467,3 +467,16 @@ string dump_tx(const struct bitcoin_tx *tx)
 	ostrm << " }";
 	return ostrm.str();
 }
+
+string dump_rhashes(const struct sha256 *rhashes, size_t num_rhashes)
+{
+	ostringstream ostrm;
+	ostrm << "[";
+	for (size_t ii = 0; ii < num_rhashes; ii++) {
+		if (ii != 0)
+			ostrm << ",";
+		ostrm << dump_hex(&rhashes[ii], sizeof(rhashes[ii]));
+	}
+	ostrm << "]";
+	return ostrm.str();
+}

--- a/contrib/remote_hsmd/dump.hpp
+++ b/contrib/remote_hsmd/dump.hpp
@@ -36,5 +36,6 @@ std::string dump_wally_tx_outputs(const struct wally_tx_output *outputs,
 std::string dump_wally_tx(const struct wally_tx *wtx);
 std::string dump_wally_psbt(const struct wally_psbt *psbt);
 std::string dump_tx(const struct bitcoin_tx *tx);
+std::string dump_rhashes(const struct sha256 *rhashes, size_t num_rhashes);
 
 #endif /* LIGHTNING_CONTRIB_REMOTE_HSMD_DUMP_H */

--- a/contrib/remote_hsmd/hsmd.c
+++ b/contrib/remote_hsmd/hsmd.c
@@ -686,12 +686,16 @@ static struct io_plan *handle_sign_remote_commitment_tx(struct io_conn *conn,
 	struct bitcoin_signature sig;
 	struct pubkey remote_per_commit;
 	bool option_static_remotekey;
+	struct sha256 *rhashes;
+	u64 commit_num;
+	u32 feerate;
 
 	if (!fromwire_hsm_sign_remote_commitment_tx(tmpctx, msg_in,
 						    &tx,
 						    &remote_funding_pubkey,
 						    &remote_per_commit,
-						    &option_static_remotekey))
+						    &option_static_remotekey,
+						    &rhashes, &commit_num, &feerate))
 		bad_req(conn, c, msg_in);
 	tx->chainparams = c->chainparams;
 
@@ -706,6 +710,7 @@ static struct io_plan *handle_sign_remote_commitment_tx(struct io_conn *conn,
 		&c->id, c->dbid,
 		&remote_per_commit,
 		option_static_remotekey,
+		rhashes, commit_num, feerate,
 		&sig);
 	if (PROXY_PERMANENT(rv))
 		status_failed(STATUS_FAIL_INTERNAL_ERROR,

--- a/contrib/remote_hsmd/hsmd.c
+++ b/contrib/remote_hsmd/hsmd.c
@@ -688,14 +688,13 @@ static struct io_plan *handle_sign_remote_commitment_tx(struct io_conn *conn,
 	bool option_static_remotekey;
 	struct sha256 *rhashes;
 	u64 commit_num;
-	u32 feerate;
 
 	if (!fromwire_hsm_sign_remote_commitment_tx(tmpctx, msg_in,
 						    &tx,
 						    &remote_funding_pubkey,
 						    &remote_per_commit,
 						    &option_static_remotekey,
-						    &rhashes, &commit_num, &feerate))
+						    &rhashes, &commit_num))
 		bad_req(conn, c, msg_in);
 	tx->chainparams = c->chainparams;
 
@@ -710,7 +709,7 @@ static struct io_plan *handle_sign_remote_commitment_tx(struct io_conn *conn,
 		&c->id, c->dbid,
 		&remote_per_commit,
 		option_static_remotekey,
-		rhashes, commit_num, feerate,
+		rhashes, commit_num,
 		&sig);
 	if (PROXY_PERMANENT(rv))
 		status_failed(STATUS_FAIL_INTERNAL_ERROR,

--- a/contrib/remote_hsmd/proxy.cc
+++ b/contrib/remote_hsmd/proxy.cc
@@ -681,7 +681,6 @@ proxy_stat proxy_handle_sign_remote_commitment_tx(
 	const struct pubkey *remote_per_commit,
 	bool option_static_remotekey,
 	struct sha256 *rhashes, u64 commit_num,
-	u32 feerate,
 	struct bitcoin_signature *o_sig)
 {
 	STATUS_DEBUG(
@@ -690,8 +689,7 @@ proxy_stat proxy_handle_sign_remote_commitment_tx(
 		"\"counterparty_funding_pubkey\":%s, "
 		"\"remote_per_commit\":%s, "
 		"\"option_static_remotekey\":%s, \"tx\":%s, "
-		"\"rhashes\":%s, \"commit_num\":%" PRIu64 ", "
-		"\"feerate\":%d }",
+		"\"rhashes\":%s, \"commit_num\":%" PRIu64 " }",
 		__FILE__, __LINE__, __FUNCTION__,
 		dump_node_id(&self_id).c_str(),
 		dump_node_id(peer_id).c_str(),
@@ -701,8 +699,7 @@ proxy_stat proxy_handle_sign_remote_commitment_tx(
 		(option_static_remotekey ? "true" : "false"),
 		dump_tx(tx).c_str(),
 		dump_rhashes(rhashes, tal_count(rhashes)).c_str(),
-		commit_num,
-		feerate
+		commit_num
 		);
 
 	last_message = "";
@@ -714,7 +711,6 @@ proxy_stat proxy_handle_sign_remote_commitment_tx(
 	marshal_single_input_tx(tx, NULL, req.mutable_tx());
 	marshal_rhashes(rhashes, req.mutable_payment_hashes());
 	req.set_commit_num(commit_num);
-	req.set_feerate_sat_per_kw(feerate);
 
 	ClientContext context;
 	SignatureReply rsp;

--- a/contrib/remote_hsmd/proxy.hpp
+++ b/contrib/remote_hsmd/proxy.hpp
@@ -90,7 +90,6 @@ proxy_stat proxy_handle_sign_remote_commitment_tx(
 	bool option_static_remotekey,
 	struct sha256 *rhashes,
 	u64 commit_num,
-	u32 feerate,
 	struct bitcoin_signature *o_sig);
 
 proxy_stat proxy_handle_get_per_commitment_point(

--- a/contrib/remote_hsmd/proxy.hpp
+++ b/contrib/remote_hsmd/proxy.hpp
@@ -88,6 +88,9 @@ proxy_stat proxy_handle_sign_remote_commitment_tx(
 	u64 dbid,
 	const struct pubkey *remote_per_commit,
 	bool option_static_remotekey,
+	struct sha256 *rhashes,
+	u64 commit_num,
+	u32 feerate,
 	struct bitcoin_signature *o_sig);
 
 proxy_stat proxy_handle_get_per_commitment_point(

--- a/hsmd/hsm_wire.csv
+++ b/hsmd/hsm_wire.csv
@@ -172,7 +172,6 @@ msgdata,hsm_sign_remote_commitment_tx,option_static_remotekey,bool,
 msgdata,hsm_sign_remote_commitment_tx,num_htlc_rhash,u16,
 msgdata,hsm_sign_remote_commitment_tx,htlc_rhash,sha256,num_htlc_rhash
 msgdata,hsm_sign_remote_commitment_tx,commit_num,u64,
-msgdata,hsm_sign_remote_commitment_tx,feerate,u32,
 
 # channeld asks HSM to sign remote HTLC tx.
 msgtype,hsm_sign_remote_htlc_tx,20

--- a/hsmd/hsm_wire.csv
+++ b/hsmd/hsm_wire.csv
@@ -169,6 +169,10 @@ msgdata,hsm_sign_remote_commitment_tx,tx,bitcoin_tx,
 msgdata,hsm_sign_remote_commitment_tx,remote_funding_key,pubkey,
 msgdata,hsm_sign_remote_commitment_tx,remote_per_commit,pubkey,
 msgdata,hsm_sign_remote_commitment_tx,option_static_remotekey,bool,
+msgdata,hsm_sign_remote_commitment_tx,num_htlc_rhash,u16,
+msgdata,hsm_sign_remote_commitment_tx,htlc_rhash,sha256,num_htlc_rhash
+msgdata,hsm_sign_remote_commitment_tx,commit_num,u64,
+msgdata,hsm_sign_remote_commitment_tx,feerate,u32,
 
 # channeld asks HSM to sign remote HTLC tx.
 msgtype,hsm_sign_remote_htlc_tx,20

--- a/hsmd/hsmd.c
+++ b/hsmd/hsmd.c
@@ -988,12 +988,16 @@ static struct io_plan *handle_sign_remote_commitment_tx(struct io_conn *conn,
 	const u8 *funding_wscript;
 	struct pubkey remote_per_commit;
 	bool option_static_remotekey;
+	struct sha256 *htlc_rhash;
+	u64 commit_num;
+	u32 feerate;
 
 	if (!fromwire_hsm_sign_remote_commitment_tx(tmpctx, msg_in,
 						    &tx,
 						    &remote_funding_pubkey,
 						    &remote_per_commit,
-						    &option_static_remotekey))
+						    &option_static_remotekey,
+						    &htlc_rhash, &commit_num, &feerate))
 		return bad_req(conn, c, msg_in);
 	tx->chainparams = c->chainparams;
 

--- a/hsmd/hsmd.c
+++ b/hsmd/hsmd.c
@@ -990,14 +990,13 @@ static struct io_plan *handle_sign_remote_commitment_tx(struct io_conn *conn,
 	bool option_static_remotekey;
 	struct sha256 *htlc_rhash;
 	u64 commit_num;
-	u32 feerate;
 
 	if (!fromwire_hsm_sign_remote_commitment_tx(tmpctx, msg_in,
 						    &tx,
 						    &remote_funding_pubkey,
 						    &remote_per_commit,
 						    &option_static_remotekey,
-						    &htlc_rhash, &commit_num, &feerate))
+						    &htlc_rhash, &commit_num))
 		return bad_req(conn, c, msg_in);
 	tx->chainparams = c->chainparams;
 

--- a/openingd/openingd.c
+++ b/openingd/openingd.c
@@ -751,7 +751,9 @@ static bool funder_finalize_channel_setup(struct state *state,
 						   *tx,
 						   &state->channel->funding_pubkey[REMOTE],
 						   &state->first_per_commitment_point[REMOTE],
-						   state->channel->option_static_remotekey);
+						   state->channel->option_static_remotekey,
+						   NULL, 0,
+						   channel_feerate(state->channel, REMOTE));
 
 	wire_sync_write(HSM_FD, take(msg));
 	msg = wire_sync_read(tmpctx, HSM_FD);
@@ -1296,7 +1298,9 @@ static u8 *fundee_channel(struct state *state, const u8 *open_channel_msg)
 						   remote_commit,
 						   &state->channel->funding_pubkey[REMOTE],
 						   &state->first_per_commitment_point[REMOTE],
-						   state->channel->option_static_remotekey);
+						   state->channel->option_static_remotekey,
+						   NULL, 0,
+						   channel_feerate(state->channel, REMOTE));
 
 	wire_sync_write(HSM_FD, take(msg));
 	msg = wire_sync_read(tmpctx, HSM_FD);

--- a/openingd/openingd.c
+++ b/openingd/openingd.c
@@ -752,8 +752,7 @@ static bool funder_finalize_channel_setup(struct state *state,
 						   &state->channel->funding_pubkey[REMOTE],
 						   &state->first_per_commitment_point[REMOTE],
 						   state->channel->option_static_remotekey,
-						   NULL, 0,
-						   channel_feerate(state->channel, REMOTE));
+						   NULL, 0);
 
 	wire_sync_write(HSM_FD, take(msg));
 	msg = wire_sync_read(tmpctx, HSM_FD);
@@ -1299,8 +1298,7 @@ static u8 *fundee_channel(struct state *state, const u8 *open_channel_msg)
 						   &state->channel->funding_pubkey[REMOTE],
 						   &state->first_per_commitment_point[REMOTE],
 						   state->channel->option_static_remotekey,
-						   NULL, 0,
-						   channel_feerate(state->channel, REMOTE));
+						   NULL, 0);
 
 	wire_sync_write(HSM_FD, take(msg));
 	msg = wire_sync_read(tmpctx, HSM_FD);


### PR DESCRIPTION
Add payment_hashes and commit_num to SignCounterpartyCommitmentTx to allow recomposition on the remote-signer.