### PR TITLE
Spawn remotesigner instances for integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -375,6 +375,10 @@ else
 PYTEST_OPTS += -x
 endif
 
+ifneq ($(PYTEST_MOREOPTS),)
+PYTEST_OPTS += $(PYTEST_MOREOPTS)
+endif
+
 check-units:
 
 check: check-units installcheck check-protos pytest

--- a/contrib/remote_hsmd/proxy.cc
+++ b/contrib/remote_hsmd/proxy.cc
@@ -59,8 +59,9 @@ proxy_stat map_status(Status const & status)
 	// FIXME - this is bogus, but the pytest framework loses our
 	// status_unusual messages.
 	if (code != StatusCode::OK) {
-		cerr << "PROXY-HSMD grpc::StatusCode " << int(code)
-		     << ": " << status.error_message()
+		cerr << "PID: " << getpid() << ' '
+		     << "PROXY-HSMD grpc::StatusCode " << int(code)
+ 		     << ": " << status.error_message()
 		     << endl;
 	}
 	switch (code) {
@@ -317,7 +318,8 @@ void proxy_setup()
 {
 	const char *endpointvar = getenv("REMOTE_HSMD_ENDPOINT");
 	const char *endpoint = endpointvar != NULL ? endpointvar : "localhost:50051";
-	STATUS_DEBUG("%s:%d %s endpoint:%s", __FILE__, __LINE__, __FUNCTION__, endpoint);
+	STATUS_DEBUG("%s:%d %s pid:%d, endpoint:%s", __FILE__, __LINE__, __FUNCTION__,
+		     getpid(), endpoint);
 	auto channel = grpc::CreateChannel(endpoint,
 					   grpc::InsecureChannelCredentials());
 	stub = Signer::NewStub(channel);

--- a/contrib/remote_hsmd/scripts/run-all-tests
+++ b/contrib/remote_hsmd/scripts/run-all-tests
@@ -1,8 +1,9 @@
 #!/usr/bin/sh
 
+
 SUBDAEMON='hsmd:remote_hsmd' \
 make \
-PYTEST_PAR=1 \
+-j12 PYTEST_PAR=24 \
 DEVELOPER=1 \
 VALGRIND=0 \
 SLOW_MACHINE=1 \

--- a/contrib/remote_hsmd/scripts/run-all-tests
+++ b/contrib/remote_hsmd/scripts/run-all-tests
@@ -1,11 +1,14 @@
 #!/usr/bin/sh
 
 
+
 SUBDAEMON='hsmd:remote_hsmd' \
+REMOTE_SIGNER_CMD=$(pwd)/../rust-lightning-signer/target/debug/server \
 make \
--j12 PYTEST_PAR=24 \
+-j32 PYTEST_PAR=64 \
 DEVELOPER=1 \
 VALGRIND=0 \
 SLOW_MACHINE=1 \
+PYTEST_MOREOPTS='--timeout=300 --timeout_method=thread' \
 pytest
 

--- a/contrib/remote_hsmd/scripts/run-one-test
+++ b/contrib/remote_hsmd/scripts/run-one-test
@@ -11,6 +11,7 @@ DEVELOPER=1 \
 VALGRIND=0 \
 SLOW_MACHINE=1 \
 SUBDAEMON='hsmd:remote_hsmd' \
+REMOTE_SIGNER_CMD=$(pwd)/../rust-lightning-signer/target/debug/server \
 pytest \
 $THETEST \
--v --timeout=550 --timeout_method=thread -x
+-v --timeout=300 --timeout_method=thread -x


### PR DESCRIPTION
Spawns a remotesigner instance for each lightningd; allows parallel integration test running.

Still having trouble getting integration suite to complete (hangs at 100%), investigating ...