### PR TITLE
Remove uneeded hsmd_sign_commitment_tx modifications

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -47,7 +47,7 @@ pip3 install --user \
 git clone https://github.com/lightningnetwork/lightning-rfc.git ../lightning-rfc
 git submodule update --init --recursive
 
-wget -q --directory-prefix=contrib/remote_hsmd https://gitlab.com/lightning-signer/rust-lightning-signer/-/raw/master/src/server/remotesigner.proto
+wget -q --directory-prefix=contrib/remote_hsmd https://gitlab.com/lightning-signer/validating-lightning-signer/-/raw/master/src/server/remotesigner.proto
 
 ./configure CC="$CC"
 cat config.vars

--- a/contrib/remote_hsmd/NOTES.md
+++ b/contrib/remote_hsmd/NOTES.md
@@ -4,9 +4,9 @@ c-lightning
 Setup
 
     (cd contrib/remote_hsmd && \
-    ln -s ../../../rust-lightning-signer/lightning-signer-server/src/server/remotesigner.proto)
+    ln -s ../../../validating-lightning-signer/lightning-signer-server/src/server/remotesigner.proto)
 
-Building
+ Building
 
     make distclean
     ./configure --enable-developer
@@ -91,7 +91,7 @@ Some popular tests:
     export THETEST=tests/test_connection.py::test_fee_limits
     export THETEST=tests/test_closing.py::test_option_upfront_shutdown_script
 
-rust-lightning-signer
+validating-lightning-signer
 ----------------------------------------------------------------
 
     cargo run --bin server -- --no-persist --test-mode |& tee log3

--- a/contrib/remote_hsmd/hsmd.c
+++ b/contrib/remote_hsmd/hsmd.c
@@ -767,16 +767,14 @@ static struct io_plan *handle_sign_commitment_tx(struct io_conn *conn,
 	struct node_id peer_id;
 	u64 dbid;
 	struct bitcoin_tx *tx;
-	struct simple_htlc **htlc;
 	u64 commit_num;
-	u32 feerate;
 	struct bitcoin_signature sig;
 
 	if (!fromwire_hsmd_sign_commitment_tx(tmpctx, msg_in,
 					     &peer_id, &dbid,
 					     &tx,
 					     &remote_funding_pubkey,
-					     &commit_num, &htlc, &feerate))
+					     &commit_num))
 		return bad_req(conn, c, msg_in);
 
 	tx->chainparams = c->chainparams;
@@ -809,8 +807,7 @@ static struct io_plan *handle_sign_commitment_tx(struct io_conn *conn,
 	} else {
 		// This is a unilateral close from our side.
 		proxy_stat rv = proxy_handle_sign_commitment_tx(
-			tx, &remote_funding_pubkey, &peer_id, dbid,
-			htlc, commit_num, feerate,  &sig);
+			&peer_id, dbid, commit_num, &sig);
 		if (PROXY_PERMANENT(rv))
 			status_failed(STATUS_FAIL_INTERNAL_ERROR,
 				      "proxy_%s failed: %s", __FUNCTION__,

--- a/contrib/remote_hsmd/proxy.cc
+++ b/contrib/remote_hsmd/proxy.cc
@@ -1131,25 +1131,17 @@ proxy_stat proxy_handle_sign_commitment_tx(
 		);
 
 	last_message = "";
-	SignHolderCommitmentTxRequest req;
+	SignHolderCommitmentTxPhase2Request req;
 	marshal_node_id(&self_id, req.mutable_node_id());
 	marshal_channel_nonce(peer_id, dbid, req.mutable_channel_nonce());
-	marshal_single_input_tx(tx, NULL, req.mutable_tx());
-	for (size_t ii = 0; ii < tal_count(htlcs); ++ii) {
-		if (htlcs[ii]->side == LOCAL) {
-			marshal_htlc(htlcs[ii], req.add_offered_htlcs());
-		} else {
-			marshal_htlc(htlcs[ii], req.add_received_htlcs());
-		}
-	}
 	req.set_commit_num(commit_num);
-	req.set_feerate_sat_per_kw(feerate);
 
 	ClientContext context;
-	SignatureReply rsp;
-	Status status = stub->SignHolderCommitmentTx(&context, req, &rsp);
+	CommitmentTxSignatureReply rsp;
+	Status status = stub->SignHolderCommitmentTxPhase2(&context, req, &rsp);
 	if (status.ok()) {
 		unmarshal_bitcoin_signature(rsp.signature(), o_sig);
+		// NOTE - ignoring rsp.htlc_signatures
 		STATUS_DEBUG("%s:%d %s { \"self_id\":%s, \"sig\":%s }",
 			     __FILE__, __LINE__, __FUNCTION__,
 			     dump_node_id(&self_id).c_str(),

--- a/contrib/remote_hsmd/proxy.cc
+++ b/contrib/remote_hsmd/proxy.cc
@@ -1105,29 +1105,20 @@ proxy_stat proxy_handle_sign_mutual_close_tx(
 }
 
 proxy_stat proxy_handle_sign_commitment_tx(
-	struct bitcoin_tx *tx,
-	const struct pubkey *counterparty_funding_pubkey,
 	struct node_id *peer_id,
 	u64 dbid,
-	struct simple_htlc **htlcs,
-	u64 commit_num, u32 feerate,
+	u64 commit_num,
 	struct bitcoin_signature *o_sig)
 {
 	STATUS_DEBUG(
 		"%s:%d %s { "
 		"\"self_id\":%s, \"peer_id\":%s, \"dbid\":%" PRIu64 ", "
-		"\"counterparty_funding_pubkey\":%s, \"tx\":%s, "
-		"\"htlcs\":%s, "
-		"\"commit_num\":%" PRIu64 ", "
-		"\"feerate\":%d }",
+		"\"commit_num\":%" PRIu64 " }",
 		__FILE__, __LINE__, __FUNCTION__,
 		dump_node_id(&self_id).c_str(),
 		dump_node_id(peer_id).c_str(),
 		dbid,
-		dump_pubkey(counterparty_funding_pubkey).c_str(),
-		dump_tx(tx).c_str(),
-		dump_htlcs((const struct simple_htlc **) htlcs, tal_count(htlcs)).c_str(),
-		commit_num, feerate
+		commit_num
 		);
 
 	last_message = "";

--- a/contrib/remote_hsmd/proxy.hpp
+++ b/contrib/remote_hsmd/proxy.hpp
@@ -135,13 +135,9 @@ proxy_stat proxy_handle_sign_mutual_close_tx(
 	struct bitcoin_signature *o_sig);
 
 proxy_stat proxy_handle_sign_commitment_tx(
-	struct bitcoin_tx *tx,
-	const struct pubkey *remote_funding_pubkey,
 	struct node_id *peer_id,
 	u64 dbid,
-	struct simple_htlc **htlc,
 	u64 commit_num,
-	u32 feerate,
 	struct bitcoin_signature *o_sig);
 
 proxy_stat proxy_handle_validate_commitment_tx(

--- a/contrib/remote_hsmd/scripts/rerun-failed-tests
+++ b/contrib/remote_hsmd/scripts/rerun-failed-tests
@@ -12,7 +12,7 @@ TEST_DEBUG=1 \
 DEVELOPER=1 \
 VALGRIND=0 \
 SUBDAEMON='hsmd:remote_hsmd' \
-REMOTE_SIGNER_CMD=$(pwd)/../rust-lightning-signer/target/debug/server \
+REMOTE_SIGNER_CMD=$(pwd)/../validating-lightning-signer/target/debug/server \
 REMOTE_SIGNER_ALLOWLIST=$(pwd)/contrib/remote_hsmd/TESTING_ALLOWLIST \
 pytest \
 $TESTS \

--- a/contrib/remote_hsmd/scripts/run-all-tests
+++ b/contrib/remote_hsmd/scripts/run-all-tests
@@ -1,7 +1,7 @@
 #!/usr/bin/sh
 
 SUBDAEMON='hsmd:remote_hsmd' \
-REMOTE_SIGNER_CMD=$(pwd)/../rust-lightning-signer/target/debug/server \
+REMOTE_SIGNER_CMD=$(pwd)/../validating-lightning-signer/target/debug/server \
 REMOTE_SIGNER_ALLOWLIST=$(pwd)/contrib/remote_hsmd/TESTING_ALLOWLIST \
 make \
 -j16 PYTEST_PAR=32 \

--- a/contrib/remote_hsmd/scripts/run-one-test
+++ b/contrib/remote_hsmd/scripts/run-one-test
@@ -12,7 +12,7 @@ DEVELOPER=1 \
 VALGRIND=0 \
 SLOW_MACHINE=0 \
 SUBDAEMON='hsmd:remote_hsmd' \
-REMOTE_SIGNER_CMD=$(pwd)/../rust-lightning-signer/target/debug/server \
+REMOTE_SIGNER_CMD=$(pwd)/../validating-lightning-signer/target/debug/server \
 REMOTE_SIGNER_ALLOWLIST=$(pwd)/contrib/remote_hsmd/TESTING_ALLOWLIST \
 pytest \
 $THETEST \

--- a/hsmd/hsmd_wire.csv
+++ b/hsmd/hsmd_wire.csv
@@ -134,9 +134,6 @@ msgdata,hsmd_sign_commitment_tx,channel_dbid,u64,
 msgdata,hsmd_sign_commitment_tx,tx,bitcoin_tx,
 msgdata,hsmd_sign_commitment_tx,remote_funding_key,pubkey,
 msgdata,hsmd_sign_commitment_tx,commit_num,u64,
-msgdata,hsmd_sign_commitment_tx,num_htlcs,u16,
-msgdata,hsmd_sign_commitment_tx,htlcs,simple_htlc,num_htlcs
-msgdata,hsmd_sign_commitment_tx,feerate,u32,
 
 msgtype,hsmd_sign_commitment_tx_reply,105
 msgdata,hsmd_sign_commitment_tx_reply,sig,bitcoin_signature,

--- a/hsmd/libhsmd.c
+++ b/hsmd/libhsmd.c
@@ -1300,9 +1300,7 @@ static u8 *handle_sign_commitment_tx(struct hsmd_client *c, const u8 *msg_in)
 	struct secret channel_seed;
 	struct bitcoin_tx *tx;
 	struct bitcoin_signature sig;
-	struct simple_htlc **htlc;
 	u64 commit_num;
-	u32 feerate;
 	struct secrets secrets;
 	const u8 *funding_wscript;
 
@@ -1310,7 +1308,7 @@ static u8 *handle_sign_commitment_tx(struct hsmd_client *c, const u8 *msg_in)
 					     &peer_id, &dbid,
 					     &tx,
 					     &remote_funding_pubkey,
-					     &commit_num, &htlc, &feerate))
+					     &commit_num))
 		return hsmd_status_malformed_request(c, msg_in);
 
 	tx->chainparams = c->chainparams;

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -657,7 +657,7 @@ u8 *towire_errorfmt(const tal_t *ctx UNNEEDED,
 u8 *towire_hsmd_sign_bolt12(const tal_t *ctx UNNEEDED, const wirestring *messagename UNNEEDED, const wirestring *fieldname UNNEEDED, const struct sha256 *merkleroot UNNEEDED, const u8 *publictweak UNNEEDED)
 { fprintf(stderr, "towire_hsmd_sign_bolt12 called!\n"); abort(); }
 /* Generated stub for towire_hsmd_sign_commitment_tx */
-u8 *towire_hsmd_sign_commitment_tx(const tal_t *ctx UNNEEDED, const struct node_id *peer_id UNNEEDED, u64 channel_dbid UNNEEDED, const struct bitcoin_tx *tx UNNEEDED, const struct pubkey *remote_funding_key UNNEEDED, u64 commit_num UNNEEDED, const struct simple_htlc **htlcs UNNEEDED, u32 feerate UNNEEDED)
+u8 *towire_hsmd_sign_commitment_tx(const tal_t *ctx UNNEEDED, const struct node_id *peer_id UNNEEDED, u64 channel_dbid UNNEEDED, const struct bitcoin_tx *tx UNNEEDED, const struct pubkey *remote_funding_key UNNEEDED, u64 commit_num UNNEEDED)
 { fprintf(stderr, "towire_hsmd_sign_commitment_tx called!\n"); abort(); }
 /* Generated stub for towire_hsmd_sign_invoice */
 u8 *towire_hsmd_sign_invoice(const tal_t *ctx UNNEEDED, const u8 *u5bytes UNNEEDED, const u8 *hrp UNNEEDED)

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -752,7 +752,7 @@ u8 *towire_gossipd_get_stripped_cupdate(const tal_t *ctx UNNEEDED, const struct 
 u8 *towire_hsmd_get_output_scriptpubkey(const tal_t *ctx UNNEEDED, u64 channel_id UNNEEDED, const struct node_id *peer_id UNNEEDED, const struct pubkey *commitment_point UNNEEDED)
 { fprintf(stderr, "towire_hsmd_get_output_scriptpubkey called!\n"); abort(); }
 /* Generated stub for towire_hsmd_sign_commitment_tx */
-u8 *towire_hsmd_sign_commitment_tx(const tal_t *ctx UNNEEDED, const struct node_id *peer_id UNNEEDED, u64 channel_dbid UNNEEDED, const struct bitcoin_tx *tx UNNEEDED, const struct pubkey *remote_funding_key UNNEEDED, u64 commit_num UNNEEDED, const struct simple_htlc **htlcs UNNEEDED, u32 feerate UNNEEDED)
+u8 *towire_hsmd_sign_commitment_tx(const tal_t *ctx UNNEEDED, const struct node_id *peer_id UNNEEDED, u64 channel_dbid UNNEEDED, const struct bitcoin_tx *tx UNNEEDED, const struct pubkey *remote_funding_key UNNEEDED, u64 commit_num UNNEEDED)
 { fprintf(stderr, "towire_hsmd_sign_commitment_tx called!\n"); abort(); }
 /* Generated stub for towire_incorrect_cltv_expiry */
 u8 *towire_incorrect_cltv_expiry(const tal_t *ctx UNNEEDED, u32 cltv_expiry UNNEEDED, const u8 *channel_update UNNEEDED)


### PR DESCRIPTION
Since we use `current_holder_commit_info` instead of passed tx and args only the `commitment_number` is needed