### PR TITLE
fix: Add missing dependency [squash into "Add remote_hsmd"]

### DIFF
--- a/contrib/remote_hsmd/Makefile
+++ b/contrib/remote_hsmd/Makefile
@@ -84,6 +84,8 @@ lightningd/remote_hsmd: $(LIGHTNINGD_RMTHSM_OBJS) $(LIGHTNINGD_LIB_OBJS) $(RMTHS
 
 contrib/remote_hsmd/remotesigner.pb.o: $(ALL_GEN_HEADERS)
 
+contrib/remote_hsmd/dump.o contrib/remote_hsmd/proxy.o: $(ALL_GEN_HEADERS)
+
 contrib/remote_hsmd/remotesigner.grpc.pb.o contrib/remote_hsmd/remotesigner.pb.o contrib/remote_hsmd/proxy.o contrib/remote_hsmd/dump.o : CPPFLAGS +=  $(CMNFLAGS) `pkg-config --cflags protobuf grpc`
 lightningd/remote_hsmd: LDLIBS += -L/usr/local/lib \
 	`pkg-config --libs protobuf grpc++`\


### PR DESCRIPTION
Next time we rebase onto `ElementsProject/lightning` squash this into "Add remote_hsmd"