### PR TITLE
Use more specific failures in validate_onchain_tx w/o dual-funding

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1126,6 +1126,7 @@ def test_v2_open(node_factory, bitcoind, chainparams):
     assert(result['status'] == 'complete')
 
 
+@unittest.skipIf(os.getenv('SUBDAEMON').startswith('hsmd:remote_hsmd') and os.getenv('VLS_PERMISSIVE') != '1', "channel push not allowed: dual-funding not supported yet")
 @pytest.mark.openchannel('v1')
 def test_funding_push(node_factory, bitcoind, chainparams):
     """ Try to push peer some sats """

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -1388,6 +1388,7 @@ def test_withdraw_nlocktime_fuzz(node_factory, bitcoind):
         raise Exception("No transaction with fuzzed nLockTime !")
 
 
+@unittest.skipIf(os.getenv('SUBDAEMON').startswith('hsmd:remote_hsmd') and os.getenv('VLS_PERMISSIVE') != '1', "addr2 and addr3 unknown to l1")
 def test_multiwithdraw_simple(node_factory, bitcoind, chainparams):
     """
     Test simple multiwithdraw usage.


### PR DESCRIPTION
use-permissive-or-skip for two tests