### PR TITLE
fix GL version skew

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -95,6 +95,8 @@ then
     make -s -j32 CC="$TARGET_HOST-gcc"
 else
     eatmydata make -j32
+    GREENLIGHT_VERSION=$(./lightningd/lightningd --version)
+    export GREENLIGHT_VERSION
     # shellcheck disable=SC2086
     eatmydata $TEST_CMD
 fi

--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -94,9 +94,15 @@ then
 
     make -s -j32 CC="$TARGET_HOST-gcc"
 else
+    git diff
     eatmydata make -j32
     GREENLIGHT_VERSION=$(./lightningd/lightningd --version)
     export GREENLIGHT_VERSION
+    git diff
+    # sometimes we get -modded added to the version
+    eatmydata make -j32
+    GREENLIGHT_VERSION=$(./lightningd/lightningd --version)
     # shellcheck disable=SC2086
+    git diff
     eatmydata $TEST_CMD
 fi


### PR DESCRIPTION
this seems to be caused by `doc/index.rst` being modified by the build process, causing a rebuild between the build and the test run when `-modded` is added to the `git describe`.

See https://gitlab.com/lightning-signer/vls-hsmd/-/jobs/3791832295#L4835
